### PR TITLE
Update Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -88,7 +88,13 @@ To start the ros bridge with rviz use:
 
 You can setup the vehicle configuration config/settings.yaml.
 
-Then you can make use of the CARLA Python API script manual_control.py.
+As we have not spawned any vehicle and have not added any sensors in our carla world there would not be any stream of data yet.
+
+You can make use of the CARLA Python API script manual_control.py.
+```
+cd <path/to/carla/>
+python manual_control.py
+```
 This spawns a vehicle with role_name='hero' which is interpreted as the ego
 vehicle as defined by the config/settings.yaml.
 


### PR DESCRIPTION
Coming from the Carla 0.8x versions where the vehicles are already spawned when we launch the carla server it was a bit confusing in the beginning why there was no data stream in ros and rostest failing. I missed manual_control.py in the documentation as it was not in block quotes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/21)
<!-- Reviewable:end -->
