### PR TITLE
Send vehicle control commands only when reciving ROS input

### DIFF
--- a/src/carla_ros_bridge/ego_vehicle.py
+++ b/src/carla_ros_bridge/ego_vehicle.py
@@ -164,9 +164,7 @@ class EgoVehicle(Vehicle):
 
         # send control command out, if there is a ROS control publisher
         ros_control_topic = rospy.get_published_topics(namespace=self.topic_name() + "/ackermann_cmd")
-        print(ros_control_topic)
         ros_control_topic.extend(rospy.get_published_topics(namespace=self.topic_name() + "/vehicle_control_cmd"))
-        print(ros_control_topic)
         if ros_control_topic:
             self.carla_actor.apply_control(vehicle_control)
 

--- a/src/carla_ros_bridge/ego_vehicle.py
+++ b/src/carla_ros_bridge/ego_vehicle.py
@@ -161,8 +161,15 @@ class EgoVehicle(Vehicle):
         vehicle_control.steer = self.info.output.steer
         vehicle_control.throttle = self.info.output.throttle
         vehicle_control.reverse = self.info.output.reverse
-        # send control command out
-        self.carla_actor.apply_control(vehicle_control)
+
+        # send control command out, if there is a ROS control publisher
+        ros_control_topic = rospy.get_published_topics(namespace=self.topic_name() + "/ackermann_cmd")
+        print(ros_control_topic)
+        ros_control_topic.extend(rospy.get_published_topics(namespace=self.topic_name() + "/vehicle_control_cmd"))
+        print(ros_control_topic)
+        if ros_control_topic:
+            self.carla_actor.apply_control(vehicle_control)
+
 
     def update_current_values(self):
         """


### PR DESCRIPTION
With this commit, the CARLA-ROS-bridge sends vehicle control commands to CARLA,
only when there is input from the ROS side.

Tested with CARLA 0.9.2 on Ubuntu 16.04

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/22)
<!-- Reviewable:end -->
