### PR TITLE
Fixed issue of vehicle not moving despite ROS input is properly set

### DIFF
--- a/src/carla_ros_bridge/ego_vehicle.py
+++ b/src/carla_ros_bridge/ego_vehicle.py
@@ -163,9 +163,9 @@ class EgoVehicle(Vehicle):
         vehicle_control.reverse = self.info.output.reverse
 
         # send control command out, if there is a ROS control publisher
-        ros_control_topic = rospy.get_published_topics(namespace=self.topic_name() + "/ackermann_cmd")
-        ros_control_topic.extend(rospy.get_published_topics(namespace=self.topic_name() + "/vehicle_control_cmd"))
-        if ros_control_topic:
+        ros_control_topic = rospy.get_published_topics(namespace='/')
+        if (any('/carla/ego_vehicle/ackermann_cmd' == x[0] for x in ros_control_topic) or
+            any('/carla/ego_vehicle/vehicle_control_cmd' == x[0] for x in ros_control_topic)):
             self.carla_actor.apply_control(vehicle_control)
 
 


### PR DESCRIPTION
The last commit introduced an issue when using ROS ackermann_msgs to
control the vehicle through the ROS bridge in CARLA. This commit fixed
this issue.

Resolves Issue #27 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/31)
<!-- Reviewable:end -->
