### PR TITLE
EgoVehicle Ackermann Control: Only apply control if a ros publisher is connected

### DIFF
--- a/src/carla_ros_bridge/gnss.py
+++ b/src/carla_ros_bridge/gnss.py
@@ -3,7 +3,7 @@
 #
 # Copyright (c) 2018-2019 Intel Labs.
 #
-# authors: Frederik Pasch (frederik.pasch@intel.com)
+# authors: Frederik Pasch
 #
 """
 Classes to handle Carla gnsss


### PR DESCRIPTION
As get_num_connections() does not report a reliable value a timeout is used instead.

If no new control command was received within 3 seconds the carla client does not get updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/46)
<!-- Reviewable:end -->
