### PR TITLE
[carla_ros_bridge] fix rviz launch file path

### DIFF
--- a/carla_ros_bridge/launch/carla_ros_bridge_with_rviz.launch
+++ b/carla_ros_bridge/launch/carla_ros_bridge_with_rviz.launch
@@ -1,4 +1,4 @@
 <launch>
-<include file="$(find carla_ros_bridge)/carla_ros_bridge.launch"  pass_all_args="True"/>
+<include file="$(find carla_ros_bridge)/launch/carla_ros_bridge.launch"  pass_all_args="True"/>
 <node pkg="rviz" type="rviz" name="rviz" args="-d $(find carla_ros_bridge)/config/carla_default_rviz.cfg.rviz"/>
 </launch>


### PR DESCRIPTION
The launch file that opens RViz has the wrong path to the base launch file. This diff fixes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/74)
<!-- Reviewable:end -->
