### PR TITLE
[carla_ackermann_control] add dependencies to package.xml

### DIFF
--- a/carla_ackermann_control/package.xml
+++ b/carla_ackermann_control/package.xml
@@ -10,6 +10,10 @@
   <build_export_depend>rospy</build_export_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>ackermann_msgs</exec_depend>
+  <exec_depend>carla_ros_bridge</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>dynamic_reconfigure</exec_depend>
   <export>
   </export>
 </package>


### PR DESCRIPTION
The `carla_ackermann_control` package is missing dependencies to `carla_ros_bridge`, which leads to build failures on a clean build (using catkin tools):

    CMake Error at /opt/ros/melodic/share/catkin/cmake/catkinConfig.cmake:83 (find_package):
    Could not find a package configuration file provided by "carla_ros_bridge"
    with any of the following names:

    carla_ros_bridgeConfig.cmake
    carla_ros_bridge-config.cmake

    Add the installation prefix of "carla_ros_bridge" to CMAKE_PREFIX_PATH or
    set "carla_ros_bridge_DIR" to a directory containing one of the above
    files.  If "carla_ros_bridge" provides a separate development package or
    SDK, be sure it has been installed.
    Call Stack (most recent call first):
    CMakeLists.txt:5 (find_package)

The diff just adds all the CMake dependencies to `package.xml` as runtime dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/86)
<!-- Reviewable:end -->
