### PR TITLE
Removing initial slash from frame_id names for tf

### DIFF
--- a/carla_ros_bridge/src/carla_ros_bridge/bridge.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/bridge.py
@@ -41,7 +41,7 @@ class CarlaRosBridge(Parent):
         """
         self.params = params
         super(CarlaRosBridge, self).__init__(
-            carla_id=0, carla_world=carla_world, frame_id='/map')
+            carla_id=0, carla_world=carla_world, frame_id='map')
 
         self.timestamp_last_run = 0.0
         self.ros_timestamp = rospy.Time()
@@ -68,7 +68,7 @@ class CarlaRosBridge(Parent):
             '/carla/objects', ObjectArray, queue_size=10)
         self.object_array = ObjectArray()
 
-        self.map = Map(carla_world=self.carla_world, parent=self, topic='/map')
+        self.map = Map(carla_world=self.carla_world, parent=self, topic='map')
 
     def destroy(self):
         """

--- a/carla_ros_bridge/src/carla_ros_bridge/sensor.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/sensor.py
@@ -149,7 +149,7 @@ class Sensor(Actor):
         """
         tf_msg = TransformStamped()
         tf_msg.header = self.get_msg_header()
-        tf_msg.header.frame_id = "/map"
+        tf_msg.header.frame_id = "map"
         tf_msg.child_frame_id = self.get_frame_id()
         tf_msg.transform = self.get_current_ros_transfrom()
         return tf_msg

--- a/carla_waypoint_publisher/src/carla_waypoint_publisher/carla_waypoint_publisher.py
+++ b/carla_waypoint_publisher/src/carla_waypoint_publisher/carla_waypoint_publisher.py
@@ -149,7 +149,7 @@ class CarlaToRosWaypointConverter(object):
         Publish the ROS message containing the waypoints
         """
         msg = Path()
-        msg.header.frame_id = "/map"
+        msg.header.frame_id = "map"
         msg.header.stamp = rospy.Time.now()
         if self.current_route is not None:
             for wp in self.current_route:


### PR DESCRIPTION
Following ROS specs towards tf2, tf_prefix it's
not supported in tf2.
This change allows packages like robot_localization
to work with ros-bridge, before that there where
a conflict between the frame_id names. Where
ros-bridge use "/map" and robot_localization
use "map".
Source: http://wiki.ros.org/tf2/Migration

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/117)
<!-- Reviewable:end -->
