### PR TITLE
configure sync mode options via launch file arguments

### DIFF
--- a/carla_ros_bridge/launch/carla_ros_bridge.launch
+++ b/carla_ros_bridge/launch/carla_ros_bridge.launch
@@ -3,10 +3,25 @@
   <arg name='host' default=''/>
   <arg name='port' default=''/>
   <arg name='rosbag_fname' default=''/>
+  <arg name='synchronous_mode' default=''/>
+  <arg name='synchronous_mode_wait_for_vehicle_control_command' default=''/>
+  <arg name='fixed_delta_seconds' default=''/>
   <param name="rosbag_fname" value="$(arg rosbag_fname)"/>
   <rosparam file="$(find carla_ros_bridge)/config/settings.yaml" command="load" />
   <param name="carla/host" value="$(arg host)" unless="$(eval host == '')"/>
   <param name="carla/port" value="$(arg port)" unless="$(eval port == '')"/>
+  <param
+    name="carla/synchronous_mode"
+    value="$(arg synchronous_mode)"
+    unless="$(eval synchronous_mode == '')"/>
+  <param
+    name="carla/synchronous_mode_wait_for_vehicle_control_command"
+    value="$(arg synchronous_mode_wait_for_vehicle_control_command)"
+    unless="$(eval synchronous_mode_wait_for_vehicle_control_command == '')"/>
+  <param
+    name="carla/fixed_delta_seconds"
+    value="$(arg fixed_delta_seconds)"
+    unless="$(eval fixed_delta_seconds == '')"/>
 
   <node pkg="carla_ros_bridge" name="carla_ros_bridge" type="bridge.py" output="screen"/>
     


### PR DESCRIPTION
Add some launch file arguments so that synchronous mode can be configured without touching the `ros-bridge` repo. This way external packages can configure the bridge as they need to. For example, I can define a custom launch file as:

```
<launch>
  <include file="$(find carla_ros_bridge)/launch/carla_ros_bridge.launch">
    <arg name="synchronous_mode" value="true"/>
    <arg name="synchronous_mode_wait_for_vehicle_control_command" value="true"/>
    <arg name="fixed_delta_seconds" value="0.1"/>
  </include>
</launch>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/164)
<!-- Reviewable:end -->
