### PR TITLE
Add infrastructure support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Latest changed
 
+* added option to reload the CARLA world
+* added node to spawn infrastructure sensors
 * rename /carla/vehicle_marker to /carla/marker (and include walkers)
 * support walkers
 * create rqt plugin to control synchronous mode

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ http://wiki.ros.org/ROS/Tutorials/InstallingandConfiguringROSEnvironment
 
 First run the simulator (see carla documentation: http://carla.readthedocs.io/en/latest/)
 
-    ./CarlaUE4.sh -windowed -ResX=320 -ResY=240 -benchmark -fps=10
+    ./CarlaUE4.sh -windowed -ResX=320 -ResY=240
 
 
 Wait for the message:
@@ -255,6 +255,11 @@ You can find further documentation [here](carla_ackermann_control/README.md).
 # Carla Ego Vehicle
 
 `carla_ego_vehicle` provides a generic way to spawn an ego vehicle and attach sensors to it. You can find further documentation [here](carla_ego_vehicle/README.md).
+
+
+# Carla Infrastructure Sensors
+
+`carla_infrastructure` provides a generic way to spawn a set of infrastructure sensors defined in a config file. You can find further documentation [here](carla_infrastructure/README.md).
 
 
 # Waypoint calculation

--- a/carla_infrastructure/CMakeLists.txt
+++ b/carla_infrastructure/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(carla_infrastructure)
+
+find_package(catkin REQUIRED COMPONENTS
+  rospy
+)
+
+catkin_python_setup()
+
+catkin_package(
+        CATKIN_DEPENDS
+        rospy
+)
+
+catkin_install_python(PROGRAMS
+  src/carla_infrastructure/carla_infrastructure.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(DIRECTORY launch/
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
+)
+
+install(DIRECTORY config/
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/config
+)

--- a/carla_infrastructure/README.md
+++ b/carla_infrastructure/README.md
@@ -1,0 +1,4 @@
+# ROS Infrastructure
+
+The reference Carla client `carla_infrastructure` can be used to spawn infrastructure sensors.
+

--- a/carla_infrastructure/config/sensors.json
+++ b/carla_infrastructure/config/sensors.json
@@ -1,0 +1,23 @@
+{
+    "sensors": [
+        {
+            "type": "sensor.camera.rgb",
+            "id": "camera01",
+            "x": 2.0, "y": 0.0, "z": 2.0, "roll": 0.0, "pitch": 0.0, "yaw": 0.0,
+            "width": 800,
+            "height": 600,
+            "fov": 100
+        },
+        {
+            "type": "sensor.lidar.ray_cast",
+            "id": "lidar01",
+            "x": 0.0, "y": 0.0, "z": 2.4, "roll": 0.0, "pitch": 0.0, "yaw": 0.0,
+            "range": 5000,
+            "channels": 32,
+            "points_per_second": 320000,
+            "upper_fov": 2.0,
+            "lower_fov": -26.8,
+            "rotation_frequency": 20
+        }
+    ]
+}

--- a/carla_infrastructure/launch/carla_infrastructure.launch
+++ b/carla_infrastructure/launch/carla_infrastructure.launch
@@ -1,0 +1,14 @@
+<!-- -->
+<launch>
+  <arg name='host' default='localhost'/>
+  <arg name='port' default='2000'/>
+  <arg name="infrastructure_sensor_definition_file"/>
+
+  <param name="/carla/host" value="$(arg host)" />
+  <param name="/carla/port" value="$(arg port)" />
+
+  <node pkg="carla_infrastructure" type="carla_infrastructure.py" name="carla_infrastructure" output="screen">
+    <param name="infrastructure_sensor_definition_file" value="$(arg infrastructure_sensor_definition_file)" />
+  </node>
+</launch>
+

--- a/carla_infrastructure/package.xml
+++ b/carla_infrastructure/package.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>carla_infrastructure</name>
+  <version>0.0.0</version>
+  <description>The carla_infrastructure package</description>
+  <maintainer email="carla.simulator@gmail.com">CARLA Simulator Team</maintainer>
+  <license>MIT</license>
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>rospy</build_depend>
+  <build_export_depend>rospy</build_export_depend>
+  <exec_depend>rospy</exec_depend>
+  <export>
+  </export>
+</package>

--- a/carla_infrastructure/setup.py
+++ b/carla_infrastructure/setup.py
@@ -1,0 +1,10 @@
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+d = generate_distutils_setup(
+    packages=['carla_infrastructure'],
+    package_dir={'': 'src'}
+)
+
+setup(**d)
+

--- a/carla_infrastructure/src/carla_infrastructure/carla_infrastructure.py
+++ b/carla_infrastructure/src/carla_infrastructure/carla_infrastructure.py
@@ -24,7 +24,7 @@ from geometry_msgs.msg import PoseWithCovarianceStamped, Pose
 import carla
 
 # ==============================================================================
-# -- CarlaEgoVehicle ------------------------------------------------------------
+# -- CarlaInfrastructure ------------------------------------------------------------
 # ==============================================================================
 
 
@@ -32,8 +32,6 @@ class CarlaInfrastructure(object):
 
     """
     Handles the spawning of the infrastructure sensors
-
-    Derive from this class and implement method sensors()
     """
 
     def __init__(self):
@@ -46,7 +44,7 @@ class CarlaInfrastructure(object):
 
     def restart(self):
         """
-        (Re)spawns the infrastructure sensors
+        Spawns the infrastructure sensors
 
         :return:
         """
@@ -108,13 +106,6 @@ class CarlaInfrastructure(object):
             sensor = self.world.spawn_actor(bp, sensor_transform)
             actors.append(sensor)
         return actors
-
-    @abstractmethod
-    def sensors(self):
-        """
-        return a list of sensors attached
-        """
-        return []
 
     def destroy(self):
         """

--- a/carla_infrastructure/src/carla_infrastructure/carla_infrastructure.py
+++ b/carla_infrastructure/src/carla_infrastructure/carla_infrastructure.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# This work is licensed under the terms of the MIT license.
+# For a copy, see <https://opensource.org/licenses/MIT>.
+
+"""
+base class for spawning infrastructure sensors in ROS
+"""
+
+from __future__ import print_function
+
+from abc import abstractmethod
+
+import os
+import random
+import math
+import json
+import rospy
+from tf.transformations import euler_from_quaternion, quaternion_from_euler
+from geometry_msgs.msg import PoseWithCovarianceStamped, Pose
+
+import carla
+
+# ==============================================================================
+# -- CarlaEgoVehicle ------------------------------------------------------------
+# ==============================================================================
+
+
+class CarlaInfrastructure(object):
+
+    """
+    Handles the spawning of the infrastructure sensors
+
+    Derive from this class and implement method sensors()
+    """
+
+    def __init__(self):
+        rospy.init_node('infrastructure', anonymous=True)
+        self.host = rospy.get_param('/carla/host', '127.0.0.1')
+        self.port = rospy.get_param('/carla/port', '2000')
+        self.sensor_definition_file = rospy.get_param('~infrastructure_sensor_definition_file')
+        self.world = None
+        self.sensor_actors = []
+
+    def restart(self):
+        """
+        (Re)spawns the infrastructure sensors
+
+        :return:
+        """
+        # Read sensors from file
+        if not os.path.exists(self.sensor_definition_file):
+            raise RuntimeError(
+                "Could not read sensor-definition from {}".format(self.sensor_definition_file))
+        json_sensors = None
+        with open(self.sensor_definition_file) as handle:
+            json_sensors = json.loads(handle.read())
+
+        # Set up the sensors
+        self.sensor_actors = self.setup_sensors(json_sensors["sensors"])
+
+    def setup_sensors(self, sensors):
+        """
+        Create the sensors defined by the user and spawn them in the world
+        :param sensors: list of sensors
+        :return:
+        """
+        actors = []
+        bp_library = self.world.get_blueprint_library()
+        for sensor_spec in sensors:
+            try:
+                bp = bp_library.find(str(sensor_spec['type']))
+                bp.set_attribute('role_name', str(sensor_spec['id']))
+                if sensor_spec['type'].startswith('sensor.camera'):
+                    bp.set_attribute('image_size_x', str(sensor_spec['width']))
+                    bp.set_attribute('image_size_y', str(sensor_spec['height']))
+                    bp.set_attribute('fov', str(sensor_spec['fov']))
+                    sensor_location = carla.Location(x=sensor_spec['x'], y=sensor_spec['y'],
+                                                     z=sensor_spec['z'])
+                    sensor_rotation = carla.Rotation(pitch=sensor_spec['pitch'],
+                                                     roll=sensor_spec['roll'],
+                                                     yaw=sensor_spec['yaw'])
+                elif sensor_spec['type'].startswith('sensor.lidar'):
+                    bp.set_attribute('range', str(sensor_spec['range']))
+                    bp.set_attribute('rotation_frequency', str(sensor_spec['rotation_frequency']))
+                    bp.set_attribute('channels', str(sensor_spec['channels']))
+                    bp.set_attribute('upper_fov', str(sensor_spec['upper_fov']))
+                    bp.set_attribute('lower_fov', str(sensor_spec['lower_fov']))
+                    bp.set_attribute('points_per_second', str(sensor_spec['points_per_second']))
+                    sensor_location = carla.Location(x=sensor_spec['x'], y=sensor_spec['y'],
+                                                     z=sensor_spec['z'])
+                    sensor_rotation = carla.Rotation(pitch=sensor_spec['pitch'],
+                                                     roll=sensor_spec['roll'],
+                                                     yaw=sensor_spec['yaw'])
+                elif sensor_spec['type'].startswith('sensor.other.gnss'):
+                    sensor_location = carla.Location(x=sensor_spec['x'], y=sensor_spec['y'],
+                                                     z=sensor_spec['z'])
+                    sensor_rotation = carla.Rotation()
+            except KeyError as e:
+                rospy.logfatal(
+                    "Sensor will not be spawned, because sensor spec is invalid: '{}'".format(e))
+                continue
+
+            # create sensor
+            sensor_transform = carla.Transform(sensor_location, sensor_rotation)
+            sensor = self.world.spawn_actor(bp, sensor_transform)
+            actors.append(sensor)
+        return actors
+
+    @abstractmethod
+    def sensors(self):
+        """
+        return a list of sensors attached
+        """
+        return []
+
+    def destroy(self):
+        """
+        destroy the current ego vehicle and its sensors
+        """
+        for i, _ in enumerate(self.sensor_actors):
+            if self.sensor_actors[i] is not None:
+                self.sensor_actors[i].destroy()
+                self.sensor_actors[i] = None
+        self.sensor_actors = []
+
+    def run(self):
+        """
+        main loop
+        """
+        client = carla.Client(self.host, self.port)
+        client.set_timeout(2.0)
+        self.world = client.get_world()
+        self.restart()
+        try:
+            rospy.spin()
+        except rospy.ROSInterruptException:
+            pass
+
+# ==============================================================================
+# -- main() --------------------------------------------------------------------
+# ==============================================================================
+
+
+def main():
+    """
+    main function
+    """
+    infrastructure = CarlaInfrastructure()
+    try:
+        infrastructure.run()
+    finally:
+        if infrastructure is not None:
+            infrastructure.destroy()
+
+
+if __name__ == '__main__':
+    main()

--- a/carla_ros_bridge/launch/carla_ros_bridge.launch
+++ b/carla_ros_bridge/launch/carla_ros_bridge.launch
@@ -6,7 +6,7 @@
   <arg name='synchronous_mode' default=''/>
   <arg name='synchronous_mode_wait_for_vehicle_control_command' default=''/>
   <arg name='fixed_delta_seconds' default=''/>
-  <arg name='carla_town' default='Town03' />
+  <arg name='carla_town' default='' />
   <param name="rosbag_fname" value="$(arg rosbag_fname)"/>
   <rosparam file="$(find carla_ros_bridge)/config/settings.yaml" command="load" />
   <param name="carla/host" value="$(arg host)" unless="$(eval host == '')"/>

--- a/carla_ros_bridge/launch/carla_ros_bridge.launch
+++ b/carla_ros_bridge/launch/carla_ros_bridge.launch
@@ -6,6 +6,7 @@
   <arg name='synchronous_mode' default=''/>
   <arg name='synchronous_mode_wait_for_vehicle_control_command' default=''/>
   <arg name='fixed_delta_seconds' default=''/>
+  <arg name='carla_town' default='Town03' />
   <param name="rosbag_fname" value="$(arg rosbag_fname)"/>
   <rosparam file="$(find carla_ros_bridge)/config/settings.yaml" command="load" />
   <param name="carla/host" value="$(arg host)" unless="$(eval host == '')"/>
@@ -22,6 +23,7 @@
     name="carla/fixed_delta_seconds"
     value="$(arg fixed_delta_seconds)"
     unless="$(eval fixed_delta_seconds == '')"/>
+  <param name="carla_town" value="$(arg carla_town)" />
 
   <node pkg="carla_ros_bridge" name="carla_ros_bridge" type="bridge.py" output="screen"/>
     

--- a/carla_ros_bridge/src/carla_ros_bridge/bridge.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/bridge.py
@@ -476,7 +476,7 @@ def main():
         carla_world = carla_client.get_world()
 
         carla_town = rospy.get_param('carla_town')
-        if carla_world.get_map().name !=  carla_town or carla_town == '':
+        if carla_world.get_map().name != carla_town or carla_town == '':
             carla_world = carla_client.load_world(carla_town)
             carla_world.tick()
 

--- a/carla_ros_bridge/src/carla_ros_bridge/bridge.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/bridge.py
@@ -475,6 +475,11 @@ def main():
 
         carla_world = carla_client.get_world()
 
+        carla_town = rospy.get_param('carla_town')
+        if carla_world.get_map().name !=  carla_town or carla_town == '':
+            carla_world = carla_client.load_world(carla_town)
+            carla_world.tick()
+
         carla_bridge = CarlaRosBridge(carla_client.get_world(), parameters)
         carla_bridge.run()
     finally:


### PR DESCRIPTION
This PR adds a ROS node that can spawn infrastructure sensors.

In addition, it is now also possible to reloaded the CARLA world via the ROS bridge by specifying the carla_town argument in the carla_ros_bridge.launch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/168)
<!-- Reviewable:end -->
