### PR TITLE
Updated Walker.py to publish Odometry messages

### DIFF
--- a/carla_ros_bridge/src/carla_ros_bridge/walker.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/walker.py
@@ -13,7 +13,6 @@ import rospy
 from derived_object_msgs.msg import Object
 from shape_msgs.msg import SolidPrimitive
 from nav_msgs.msg import Odometry
-from geometry_msgs.msg import Twist
 
 from carla_ros_bridge.actor import Actor
 from carla_msgs.msg import CarlaWalkerControl
@@ -82,8 +81,7 @@ class Walker(Actor):
         odometry.child_frame_id = self.get_prefix()
         odometry.pose.pose = self.get_current_ros_pose()
         odometry.twist.twist = self.get_current_ros_twist()
-        self.publish_message(self.get_topic_prefix() + "/odometry", odometry)
-        
+        self.publish_message(self.get_topic_prefix() + "/odometry", odometry)       
         
     def update(self, frame, timestamp):
         """

--- a/carla_ros_bridge/src/carla_ros_bridge/walker.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/walker.py
@@ -81,8 +81,8 @@ class Walker(Actor):
         odometry.child_frame_id = self.get_prefix()
         odometry.pose.pose = self.get_current_ros_pose()
         odometry.twist.twist = self.get_current_ros_twist()
-        self.publish_message(self.get_topic_prefix() + "/odometry", odometry)       
-        
+        self.publish_message(self.get_topic_prefix() + "/odometry", odometry)
+
     def update(self, frame, timestamp):
         """
         Function (override) to update this object.


### PR DESCRIPTION
Added a helper function (send_walker_msgs) to publish odometry messages for walker (pedestrians) Added a function call to send_walker_msgs within update This change is to enable the walker/pedestrians to automatically publish their odometry information via ros-bridge.