### PR TITLE
Fix scenario runner timeout

### DIFF
--- a/carla_ros_scenario_runner/src/carla_ros_scenario_runner/scenario_runner_runner.py
+++ b/carla_ros_scenario_runner/src/carla_ros_scenario_runner/scenario_runner_runner.py
@@ -29,5 +29,6 @@ class ScenarioRunnerRunner(ApplicationRunner):
         cmdline = ["/usr/bin/python", "{}/scenario_runner.py".format(self._path),
                    "--openscenario", "{}".format(scenario_file),
                    "--waitForEgo",
+                   "--timeout", "1000000",
                    "--host", self._host]
         return self.execute(cmdline, env=os.environ)


### PR DESCRIPTION
In order to not run into a timeout while pausing the simulation, set scenario runner timeout to 1000000

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/250)
<!-- Reviewable:end -->
