### PR TITLE
Add role name to imu topic

### DIFF
--- a/carla_ros_bridge/src/carla_ros_bridge/imu.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/imu.py
@@ -39,7 +39,7 @@ class ImuSensor(Sensor):
                                         parent=parent,
                                         communication=communication,
                                         synchronous_mode=synchronous_mode,
-                                        prefix="imu")
+                                        prefix="imu" + carla_actor.attributes.get('role_name'))
 
     # pylint: disable=arguments-differ
     def sensor_data_updated(self, carla_imu_measurement):

--- a/carla_ros_bridge/src/carla_ros_bridge/imu.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/imu.py
@@ -39,7 +39,7 @@ class ImuSensor(Sensor):
                                         parent=parent,
                                         communication=communication,
                                         synchronous_mode=synchronous_mode,
-                                        prefix="imu" + carla_actor.attributes.get('role_name'))
+                                        prefix="imu/" + carla_actor.attributes.get('role_name'))
 
     # pylint: disable=arguments-differ
     def sensor_data_updated(self, carla_imu_measurement):


### PR DESCRIPTION
All IMU sensors publish readings on one topic e.g. /carla/ego_vehicle/imu. The subject name should contain sensor role name as for other sensors. This change should resolve this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/256)
<!-- Reviewable:end -->
