### PR TITLE
Added support for multiple IMUs

### DIFF
--- a/carla_ros_bridge/src/carla_ros_bridge/imu.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/imu.py
@@ -22,7 +22,7 @@ class ImuSensor(Sensor):
     Actor implementation details for imu sensor
     """
 
-    def __init__(self, carla_actor, parent, communication, synchronous_mode):
+    def __init__(self, carla_actor, parent, communication, synchronous_mode, prefix=None):  # pylint: disable=too-many-arguments
         """
         Constructor
 
@@ -34,12 +34,17 @@ class ImuSensor(Sensor):
         :type communication: carla_ros_bridge.communication
         :param synchronous_mode: use in synchronous mode?
         :type synchronous_mode: bool
+        :param prefix: the topic prefix to be used for this actor.
+            If None, defaults to 'imu/<actor role name>'
+        :type prefix: string
         """
+        if prefix is None:
+            prefix = 'imu/' + carla_actor.attributes.get('role_name')
         super(ImuSensor, self).__init__(carla_actor=carla_actor,
                                         parent=parent,
                                         communication=communication,
                                         synchronous_mode=synchronous_mode,
-                                        prefix="imu")
+                                        prefix=prefix)
 
     # pylint: disable=arguments-differ
     def sensor_data_updated(self, carla_imu_measurement):


### PR DESCRIPTION
Before, if you added multiple IMUs to a vehicle, they would all attempt to publish to the same ROS topic: `/carla/<vehicle role name>/imu`. Now, they follow the convention of other sensors, like cameras and lidars, and publish to `/carla/<vehicle role name>/imu/<imu role name>`.

To test this, I used the `ego_vehicle` package, with a custom `sensors.json` file which includes two separate IMUs. For example:

        {
            "type": "sensor.other.imu",
            "id": "imu0",
            "x": 40.0, "y": 0.0, "z": 2.0, "roll": 0.0, "pitch": 0.0, "yaw": 0.0,
            "noise_accel_stddev_x": 1e-4, "noise_accel_stddev_y": 1e-4, "noise_accel_stddev_z": 1e-4,
            "noise_gyro_stddev_x": 1e-4, "noise_gyro_stddev_y": 1e-4, "noise_gyro_stddev_z": 1e-4,
            "noise_gyro_bias_x": 0.0, "noise_gyro_bias_y": 0.0, "noise_gyro_bias_z": 0.0
        },
        {
            "type": "sensor.other.imu",
            "id": "imu1",
            "x": 0.0, "y": 0.0, "z": 0.0, "roll": 0.0, "pitch": 0.0, "yaw": 0.0,
            "noise_accel_stddev_x": 1e-4, "noise_accel_stddev_y": 1e-4, "noise_accel_stddev_z": 1e-4,
            "noise_gyro_stddev_x": 1e-4, "noise_gyro_stddev_y": 1e-4, "noise_gyro_stddev_z": 1e-4,
            "noise_gyro_bias_x": 0.0, "noise_gyro_bias_y": 0.0, "noise_gyro_bias_z": 0.0
        }

There are now two separate ROS topics:

  - `/carla/ego_vehicle/imu/imu0`
  - `/carla/ego_vehicle/imu/imu1`

And two separate TF frames:

  - `ego_vehicle/imu/imu0`
  - `ego_vehicle/imu/imu1`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/266)
<!-- Reviewable:end -->
