### PR TITLE
[ROS2] Fix crash when using an ego vehicle

### DIFF
--- a/carla_ros_bridge/src/carla_ros_bridge/bridge.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/bridge.py
@@ -446,8 +446,6 @@ class CarlaRosBridge(CompatibleNode):
                 pseudo_actors.append(
                     ObjectSensor(parent=actor, node=self, actor_list=self.actors,
                                  filtered_id=carla_actor.id))
-                if ROS_VERSION == 2:
-                    self.executor.add_node(actor)
             else:
                 actor = Vehicle(carla_actor, parent, self)
         elif carla_actor.type_id.startswith("sensor"):


### PR DESCRIPTION
This PR fixes a crash of the bridge when an ego vehicle is used. The crash happens due to a faulty method call. The code in question is this:

https://github.com/carla-simulator/ros-bridge/blob/0a05b7fad550f90c25be9dc68bed92be0c0d5364/carla_ros_bridge/src/carla_ros_bridge/bridge.py#L444-L450

The parameter of `add_node` is of type `rclpy.node.Node`, but it is passed an `EgoVehicle` as argument, which is not a subtype of `Node`. The registration of the bridge node is already happening in `main()` by calling the `add_node` method there. Thus, I think removing the above lines should be fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/346)
<!-- Reviewable:end -->
