### PR TITLE
[ROS2] Fix attribute types of ColorRGBA instances

### DIFF
--- a/carla_ros_bridge/src/carla_ros_bridge/actor.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/actor.py
@@ -139,9 +139,9 @@ class Actor(PseudoActor):
         :rtpye : std_msgs.msg.ColorRGBA
         """
         color = ColorRGBA()
-        color.r = 0
-        color.g = 0
-        color.b = 255
+        color.r = 0.0
+        color.g = 0.0
+        color.b = 255.0
         return color
 
     def get_marker(self):

--- a/carla_ros_bridge/src/carla_ros_bridge/vehicle.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/vehicle.py
@@ -60,9 +60,9 @@ class Vehicle(TrafficParticipant):
         :rtpye : std_msgs.msg.ColorRGBA
         """
         color = ColorRGBA()
-        color.r = 255
-        color.g = 0
-        color.b = 0
+        color.r = 255.0
+        color.g = 0.0
+        color.b = 0.0
         return color
 
     def get_classification(self):


### PR DESCRIPTION
This PR changes two instances of `ColorRGBA` to be initialized with the proper type of values, by that preventing the bridge from crashing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/350)
<!-- Reviewable:end -->
