### PR TITLE
Updated user installtion process

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This will install carla-ros-bridge in /opt/carla-ros-bridge
     git submodule update --init
     cd ../catkin_ws/src
     ln -s ../../ros-bridge
-    source /opt/ros/kinetic/setup.bash
+    source /opt/ros/<kinetic or melodic>/setup.bash
     cd ..
 
     #install required ros-dependencies

--- a/README.md
+++ b/README.md
@@ -39,20 +39,15 @@ For a quick overview, after following the [Setup section](#setup), please run th
 
 First add the apt repository:
 
-##### For ROS Melodic Users
-    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 81061A1A042F527D &&
-    sudo add-apt-repository "deb [arch=amd64 trusted=yes] http://dist.carla.org/carla-ros-bridge-melodic/ bionic main"
-
-##### For ROS Kinetic Users
-    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 9BE2A0CDC0161D6C &&
-    sudo add-apt-repository "deb [arch=amd64 trusted=yes] http://dist.carla.org/carla-ros-bridge-kinetic xenial main"
+    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1AF1527DE64CB8D9
+    sudo add-apt-repository "deb [arch=amd64] http://dist.carla.org/carla $(lsb_release -sc) main"
 
 Then simply install the ROS bridge:
 
-    sudo apt update &&
-    sudo apt install carla-ros-bridge-<melodic or kinetic>
+    sudo apt-get update
+    sudo apt-get install carla-ros-bridge
 
-This will install carla-ros-bridge-<melodic or kinetic> in /opt/carla-ros-bridge
+This will install carla-ros-bridge in /opt/carla-ros-bridge
 
 ### For Developers
 


### PR DESCRIPTION
The installation process of the debian package has been modified. Now, both packages (i.e., `carla-simulator` and `carla-ros-bridge`) are inside the same apt repository and all the future updates will be added in this same repository.

The installation process now is as follows:
```sh
sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1AF1527DE64CB8D9
sudo add-apt-repository "deb [arch=amd64] http://dist.carla.org/carla $(lsb_release -sc) main"

sudo apt-get update
sudo apt-get install carla-simulator
sudo apt-get install carla-ros-bridge
```

It is also possible to install specific versions:

```
sudo apt-get install carla-simulator=0.9.10-1
sudo apt-get install carla-ros-bridge=0.9.10-1
```

To install ROS bridge versions prior to 0.9.10, the older instructions should be followed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/363)
<!-- Reviewable:end -->
