### PR TITLE
Update ros2 requirements documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ jobs:
         apt:
           packages:
           - python3-pip
-          - libsdl2-dev
+          - libsdl1.2-dev
     - name: "Docker Kinetic"
       stage: docker
       services: docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ jobs:
         apt:
           packages:
           - python3-pip
-          - libsdl1.2-dev
+          - python3-pygame
     - name: "Docker Kinetic"
       stage: docker
       services: docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ jobs:
         apt:
           packages:
           - python3-pip
+          - libsdl2-dev
     - name: "Docker Kinetic"
       stage: docker
       services: docker

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ This will install carla-ros-bridge-<melodic or kinetic> in /opt/carla-ros-bridge
 For more information about configuring a ROS environment see
 <http://wiki.ros.org/ROS/Tutorials/InstallingandConfiguringROSEnvironment>
 
+#### Using ROS2
+
+In development
+
+To test the ROS2 implementation, the rmw_fasrtps_cpp RMW implementation should be used. (default with ROS2 standard installation).
+
 ## Start the ROS bridge
 
 First run the simulator (see carla documentation: <http://carla.readthedocs.io/en/latest/>)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ pep8
 autopep8
 cmake_format
 pylint
+transforms3d
+pygame


### PR DESCRIPTION
I had to install manually the python packages pygame and transforms3d, so I added them to requirements.txt. I think rosdep should be able to install these, but it wasn't working.

I also added a ROS2 section in the documentation. The main reason was to note that the RMW implementation rmw_fastrtps_cpp should be used with ROS2, I initially was using rmw_connext_cpp and couldn't get the ros2 nodes running.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/365)
<!-- Reviewable:end -->
