### PR TITLE
added some required default values in ros2 launch files, and correcte…

### DIFF
--- a/carla_ego_vehicle/launch/carla_ego_vehicle.launch
+++ b/carla_ego_vehicle/launch/carla_ego_vehicle.launch
@@ -11,9 +11,6 @@
   <arg name="remap_rviz_initialpose_goal" default="True"/>
   <arg name="spawn_ego_vehicle" default="True" />
 
-  <param name="/carla/host" value="$(arg host)" />
-  <param name="/carla/port" value="$(arg port)" />
-  <param name="/carla/timeout" value="$(arg timeout)" />
 
   <!-- 
     If enabled, remap topics to support setting initialpose and goal with RVIZ
@@ -31,5 +28,9 @@
     <param name="spawn_point" value="$(arg spawn_point)" />
     <param name="role_name" value="$(arg role_name)" />
     <param name="spawn_ego_vehicle" value="$(arg spawn_ego_vehicle)" />
+
+    <param name="carla/host" value="$(arg host)" />
+    <param name="carla/port" value="$(arg port)" />
+    <param name="carla/timeout" value="$(arg timeout)" />
   </node>
 </launch>

--- a/carla_ego_vehicle/launch/carla_ego_vehicle.launch.py
+++ b/carla_ego_vehicle/launch/carla_ego_vehicle.launch.py
@@ -24,7 +24,8 @@ def generate_launch_description():
             default_value='vehicle.*'
         ),
         launch.actions.DeclareLaunchArgument(
-            name='sensor_definition_file'
+            name='sensor_definition_file',
+            default_value=''
         ),
         launch.actions.DeclareLaunchArgument(
             name='role_name',
@@ -87,13 +88,13 @@ def generate_launch_description():
             output='screen',
             parameters=[
                 {
-                    '/carla/host': launch.substitutions.LaunchConfiguration('host')
+                    'carla/host': launch.substitutions.LaunchConfiguration('host')
                 },
                 {
-                    '/carla/port': launch.substitutions.LaunchConfiguration('port')
+                    'carla/port': launch.substitutions.LaunchConfiguration('port')
                 },
                 {
-                    '/carla/timeout': launch.substitutions.LaunchConfiguration('timeout')
+                    'carla/timeout': launch.substitutions.LaunchConfiguration('timeout')
                 },
                 {
                     'sensor_definition_file': launch.substitutions.LaunchConfiguration('sensor_definition_file')

--- a/carla_ego_vehicle/src/carla_ego_vehicle/carla_ego_vehicle.py
+++ b/carla_ego_vehicle/src/carla_ego_vehicle/carla_ego_vehicle.py
@@ -70,9 +70,9 @@ class CarlaEgoVehicle(CompatibleNode):
 
         if ROS_VERSION == 1:
             self.sensor_definition_file = self.get_param('sensor_definition_file', 'sensors.json')
-        elif ROS_VERSION == 2:           
+        elif ROS_VERSION == 2:
             sensor_path = get_package_share_directory('carla_ego_vehicle') + '/config/sensors.json'
-            self.sensor_definition_file = self.get_param('sensor_definition_file', sensor_path)           
+            self.sensor_definition_file = self.get_param('sensor_definition_file', sensor_path)
         if spawn_point_param and self.spawn_ego_vehicle():
             self.loginfo("Using ros parameter for spawnpoint: {}".format(spawn_point_param))
             spawn_point = spawn_point_param.split(',')

--- a/carla_ego_vehicle/src/carla_ego_vehicle/carla_ego_vehicle.py
+++ b/carla_ego_vehicle/src/carla_ego_vehicle/carla_ego_vehicle.py
@@ -60,27 +60,19 @@ class CarlaEgoVehicle(CompatibleNode):
         self.player_created = False
         self.sensor_actors = []
         self.actor_spawnpoint = None
-        self.timeout = self.get_param('/carla/timeout', 2)
+        self.timeout = self.get_param('carla/timeout', 2)
+        self.host = self.get_param('carla/host', 'localhost')
+        self.port = self.get_param('carla/port', 2000)
+        self.actor_filter = self.get_param('vehicle_filter', 'vehicle.*')
+        self.role_name = self.get_param('role_name', 'ego_vehicle')
+        # check argument and set spawn_point
+        spawn_point_param = self.get_param('spawn_point')
 
         if ROS_VERSION == 1:
-            self.host = self.get_param('/carla/host', '127.0.0.1')
-            self.port = self.get_param('/carla/port', '2000')
-            self.sensor_definition_file = self.get_param('~sensor_definition_file', 'sensors.json')
-            self.actor_filter = self.get_param('~vehicle_filter', 'vehicle.*')
-            self.role_name = self.get_param('~role_name', 'ego_vehicle')
-            # check argument and set spawn_point
-            spawn_point_param = self.get_param('~spawn_point')
-
-        elif ROS_VERSION == 2:
-            self.host = self.get_param('carla.host', 'localhost')
-            self.port = self.get_param('carla.port', 2000)
+            self.sensor_definition_file = self.get_param('sensor_definition_file', 'sensors.json')
+        elif ROS_VERSION == 2:           
             sensor_path = get_package_share_directory('carla_ego_vehicle') + '/config/sensors.json'
-            self.sensor_definition_file = self.get_param('sensor_definition_file', sensor_path)
-            self.actor_filter = self.get_param('vehicle_filter', 'vehicle.*')
-            self.role_name = self.get_param('role_name', 'ego_vehicle')
-            # check argument and set spawn_point
-            spawn_point_param = self.get_param('spawn_point')
-
+            self.sensor_definition_file = self.get_param('sensor_definition_file', sensor_path)           
         if spawn_point_param and self.spawn_ego_vehicle():
             self.loginfo("Using ros parameter for spawnpoint: {}".format(spawn_point_param))
             spawn_point = spawn_point_param.split(',')

--- a/carla_ros_bridge/launch/carla_ros_bridge.launch.py
+++ b/carla_ros_bridge/launch/carla_ros_bridge.launch.py
@@ -10,31 +10,31 @@ def generate_launch_description():
     ld = launch.LaunchDescription([
         launch.actions.DeclareLaunchArgument(
             name='host',
-            default_value=''
+            default_value='localhost'
         ),
         launch.actions.DeclareLaunchArgument(
             name='port',
-            default_value=''
+            default_value='2000'
         ),
         launch.actions.DeclareLaunchArgument(
             name='timeout',
-            default_value=''
+            default_value='2'
         ),
         launch.actions.DeclareLaunchArgument(
             name='synchronous_mode',
-            default_value=''
+            default_value='False'
         ),
         launch.actions.DeclareLaunchArgument(
             name='synchronous_mode_wait_for_vehicle_control_command',
-            default_value=''
+            default_value='True'
         ),
         launch.actions.DeclareLaunchArgument(
             name='fixed_delta_seconds',
-            default_value=''
+            default_value='0.05'
         ),
         launch.actions.DeclareLaunchArgument(
             name='town',
-            default_value=''
+            default_value='Town01'
         ),
         launch.actions.DeclareLaunchArgument(
             name='ego_vehicle_role_names',
@@ -52,28 +52,28 @@ def generate_launch_description():
                     'use_sim_time': True
                 },
                 {
-                    'carla/host': launch.substitutions.LaunchConfiguration('host')
+                    'host': launch.substitutions.LaunchConfiguration('host')
                 },
                 {
-                    'carla/port': launch.substitutions.LaunchConfiguration('port')
+                    'port': launch.substitutions.LaunchConfiguration('port')
                 },
                 {
-                    'carla/timeout': launch.substitutions.LaunchConfiguration('timeout')
+                    'timeout': launch.substitutions.LaunchConfiguration('timeout')
                 },
                 {
-                    'carla/synchronous_mode': launch.substitutions.LaunchConfiguration('synchronous_mode')
+                    'synchronous_mode': launch.substitutions.LaunchConfiguration('synchronous_mode')
                 },
                 {
-                    'carla/synchronous_mode_wait_for_vehicle_control_command': launch.substitutions.LaunchConfiguration('synchronous_mode_wait_for_vehicle_control_command')
+                    'synchronous_mode_wait_for_vehicle_control_command': launch.substitutions.LaunchConfiguration('synchronous_mode_wait_for_vehicle_control_command')
                 },
                 {
-                    'carla/fixed_delta_seconds': launch.substitutions.LaunchConfiguration('fixed_delta_seconds')
+                    'fixed_delta_seconds': launch.substitutions.LaunchConfiguration('fixed_delta_seconds')
                 },
                 {
-                    'carla/town': launch.substitutions.LaunchConfiguration('town')
+                    'town': launch.substitutions.LaunchConfiguration('town')
                 },
                 {
-                    'carla/ego_vehicle/role_name': launch.substitutions.LaunchConfiguration('ego_vehicle_role_names')
+                    'ego_vehicle_role_name': launch.substitutions.LaunchConfiguration('ego_vehicle_role_names')
                 }
             ]
         )

--- a/carla_ros_bridge/launch/carla_ros_bridge_with_example_ego_vehicle.launch.py
+++ b/carla_ros_bridge/launch/carla_ros_bridge_with_example_ego_vehicle.launch.py
@@ -34,19 +34,19 @@ def generate_launch_description():
         ),
         launch.actions.DeclareLaunchArgument(
             name='town',
-            default_value=''
+            default_value='Town01'
         ),
         launch.actions.DeclareLaunchArgument(
             name='synchronous_mode',
-            default_value=''
+            default_value='False'
         ),
         launch.actions.DeclareLaunchArgument(
             name='synchronous_mode_wait_for_vehicle_control_command',
-            default_value=''
+            default_value='True'
         ),
         launch.actions.DeclareLaunchArgument(
             name='fixed_delta_seconds',
-            default_value=''
+            default_value='0.05'
         ),
         launch.actions.IncludeLaunchDescription(
             launch.launch_description_sources.PythonLaunchDescriptionSource(


### PR DESCRIPTION
…d carla_ego_vehicle that was using global parameters.

- In ros2 launchfiles some parameters were created without default values, potentially causing errors.
- In ros2 launchfile carla_ros_bridge, the names of the parameters defined were different (added "carla/") than those used in bridge.py
- carla_ego_vehicle.py (ros1 case) was trying to access global parameters, which is forbidden when using the ros_compatibility 
  node, I also had to redefine these parameters as private in the corresponding ros1 launchfile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/367)
<!-- Reviewable:end -->
