### PR TITLE
remove inheritance on CompatibleNode for sensor in carla_ros_bridge

### DIFF
--- a/carla_ros_bridge/src/carla_ros_bridge/camera.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/camera.py
@@ -56,8 +56,10 @@ class Camera(Sensor):
                                      synchronous_mode=synchronous_mode,
                                      prefix=prefix, sensor_name=sensor_name)
 
+        self.node = node
+
         if self.__class__.__name__ == "Camera":
-            self.logwarn("Created Unsupported Camera Actor"
+            self.node.logwarn("Created Unsupported Camera Actor"
                          "(id={}, parent_id={}, type={}, attributes={})".format(
                              self.get_id(), self.get_parent_id(), self.carla_actor.type_id,
                              self.carla_actor.attributes))
@@ -111,7 +113,7 @@ class Camera(Sensor):
         """
         if ((carla_image.height != self._camera_info.height) or
                 (carla_image.width != self._camera_info.width)):
-            self.logerr("Camera{} received image not matching configuration".format(
+            self.node.logerr("Camera{} received image not matching configuration".format(
                 self.get_prefix()))
         image_data_array, encoding = self.get_carla_image_data_array(
             carla_image=carla_image)


### PR DESCRIPTION
In carla_ros_bridge the sensor class was inheriting from CompatibleNode, so a new ros node was created for each sensor in ros2. This was causing problems, as if one type of sensor was spawned several times, several nodes with same name were created.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/391)
<!-- Reviewable:end -->
