### PR TITLE
ported pcl_recorder to ros2

### DIFF
--- a/pcl_recorder/CMakeLists.txt
+++ b/pcl_recorder/CMakeLists.txt
@@ -1,29 +1,82 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.3)
 project(pcl_recorder)
 
-find_package(catkin REQUIRED COMPONENTS pcl_conversions pcl_ros roscpp
-                                        sensor_msgs roslaunch)
+find_package(ros_environment REQUIRED)
+set(ROS_VERSION $ENV{ROS_VERSION})
 
-catkin_package()
+if(${ROS_VERSION} EQUAL 1)
 
-roslaunch_add_file_check(launch DEPENDENCIES ${PROJECT_NAME}_node)
+  find_package(catkin REQUIRED COMPONENTS pcl_conversions pcl_ros roscpp
+                                          sensor_msgs roslaunch)
 
-include_directories(include ${catkin_INCLUDE_DIRS})
+  catkin_package()
 
-add_executable(${PROJECT_NAME}_node src/PclRecorder.cpp src/main.cpp)
+  roslaunch_add_file_check(launch DEPENDENCIES ${PROJECT_NAME}_node)
 
-target_link_libraries(${PROJECT_NAME}_node ${catkin_LIBRARIES})
+  include_directories(include ${catkin_INCLUDE_DIRS})
 
-target_compile_features(
-  ${PROJECT_NAME}_node
-  PRIVATE cxx_inheriting_constructors cxx_lambdas cxx_auto_type
-          cxx_variadic_templates cxx_variable_templates)
+  add_executable(${PROJECT_NAME}_node src/PclRecorder.cpp src/main.cpp)
 
-install(
-  TARGETS ${PROJECT_NAME}_node
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+  target_link_libraries(${PROJECT_NAME}_node ${catkin_LIBRARIES})
 
-install(DIRECTORY launch/
-        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch)
+  target_compile_features(
+    ${PROJECT_NAME}_node
+    PRIVATE cxx_inheriting_constructors cxx_lambdas cxx_auto_type
+            cxx_variadic_templates cxx_variable_templates)
+
+  install(
+    TARGETS ${PROJECT_NAME}_node
+    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+  install(DIRECTORY launch/
+          DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch)
+
+elseif(${ROS_VERSION} EQUAL 2)
+  # Default to C++14
+  if(NOT CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 14)
+  endif()
+
+  if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options(-Wall -Wextra -Wpedantic)
+  endif()
+
+  find_package(ament_cmake REQUIRED)
+  find_package(rclcpp REQUIRED)
+  find_package(rclcpp_components REQUIRED)
+  find_package(sensor_msgs COMPONENTS)
+  find_package(tf2 REQUIRED)
+  find_package(tf2_geometry_msgs REQUIRED)
+  find_package(tf2_ros REQUIRED)
+  find_package(pcl_conversions REQUIRED)
+
+  find_package(
+    Boost
+    COMPONENTS system
+    REQUIRED)
+  find_package(PCL REQUIRED COMPONENTS common io)
+
+  include_directories(include ${PCL_INCLUDE_DIRS})
+
+  add_executable(${PROJECT_NAME}_node src/PclRecorderROS2.cpp src/mainROS2.cpp)
+
+  ament_target_dependencies(${PROJECT_NAME}_node rclcpp sensor_msgs
+                            pcl_conversions tf2_ros tf2)
+
+  target_link_libraries(${PROJECT_NAME}_node ${Boost_SYSTEM_LIBRARY}
+                        ${PCL_LIBRARIES})
+
+  target_compile_features(
+    ${PROJECT_NAME}_node
+    PRIVATE cxx_inheriting_constructors cxx_lambdas cxx_auto_type
+            cxx_variadic_templates cxx_variable_templates)
+
+  install(TARGETS ${PROJECT_NAME}_node DESTINATION lib/${PROJECT_NAME})
+
+  install(DIRECTORY launch/ DESTINATION share/${PROJECT_NAME}/)
+
+  ament_package()
+
+endif()

--- a/pcl_recorder/include/PclRecorderROS2.h
+++ b/pcl_recorder/include/PclRecorderROS2.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019 Intel Corporation
+ *
+ * This work is licensed under the terms of the MIT license.
+ * For a copy, see <https://opensource.org/licenses/MIT>.
+ */
+#pragma once
+
+#include "rclcpp/rclcpp.hpp"
+#include <pcl_conversions/pcl_conversions.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+#include <tf2_eigen/tf2_eigen.h>
+#include "std_msgs/msg/string.hpp"
+#include <rclcpp/time_source.hpp>
+
+class PclRecorderROS2 : public rclcpp::Node
+{
+public:
+
+  PclRecorderROS2();
+
+  void callback(const sensor_msgs::msg::PointCloud2::SharedPtr cloud);
+
+private:
+  rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr sub;
+  std::unique_ptr<tf2_ros::Buffer> tf_buffer_ = nullptr;
+  tf2_ros::TransformListener *tfListener;
+  static constexpr const char* fixed_frame_ = "map";
+
+};

--- a/pcl_recorder/include/PclRecorderROS2.h
+++ b/pcl_recorder/include/PclRecorderROS2.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Intel Corporation
+ * Copyright (c) 2019-2020 Intel Corporation
  *
  * This work is licensed under the terms of the MIT license.
  * For a copy, see <https://opensource.org/licenses/MIT>.
@@ -11,7 +11,6 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 #include <tf2_eigen/tf2_eigen.h>
-#include "std_msgs/msg/string.hpp"
 #include <rclcpp/time_source.hpp>
 
 class PclRecorderROS2 : public rclcpp::Node

--- a/pcl_recorder/launch/pcl_recorder.launch.py
+++ b/pcl_recorder/launch/pcl_recorder.launch.py
@@ -20,11 +20,11 @@ def generate_launch_description():
             name='role_name',
             default_value='ego_vehicle'
         ),
-        launch_ros.actions.Node(
-            package='rostopic',
-            node_executable='rostopic',
-            name='enable_autopilot_rostopic'
-        ),
+        # launch_ros.actions.Node(
+        #     package='rostopic',
+        #     node_executable='rostopic',
+        #     name='enable_autopilot_rostopic'
+        # ),
         launch_ros.actions.Node(
             package='pcl_recorder',
             node_executable='pcl_recorder_node',

--- a/pcl_recorder/package.xml
+++ b/pcl_recorder/package.xml
@@ -14,19 +14,19 @@
   <build_export_depend condition="$ROS_VERSION == 1">roscpp</build_export_depend>
   <exec_depend condition="$ROS_VERSION == 1">roscpp</exec_depend>
   <exec_depend condition="$ROS_VERSION == 1">rostopic</exec_depend>
+  <build_depend condition="$ROS_VERSION == 1">pcl_ros</build_depend>
+  <build_export_depend condition="$ROS_VERSION == 1">pcl_ros</build_export_depend>
+  <exec_depend condition="$ROS_VERSION == 1">pcl_ros</exec_depend>
 
   <!-- ROS 2 DEPENDENCIES-->
   <depend condition="$ROS_VERSION == 2">rclcpp</depend>
   <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
 
   <build_depend>pcl_conversions</build_depend>
-  <!-- <build_depend>pcl_ros</build_depend> -->
   <build_depend>sensor_msgs</build_depend>
   <build_export_depend>pcl_conversions</build_export_depend>
-  <!-- <build_export_depend>pcl_ros</build_export_depend> -->
   <build_export_depend>sensor_msgs</build_export_depend>
   <exec_depend>pcl_conversions</exec_depend>
-  <!-- <exec_depend>pcl_ros</exec_depend> -->
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>carla_ros_bridge</exec_depend>
   

--- a/pcl_recorder/package.xml
+++ b/pcl_recorder/package.xml
@@ -1,26 +1,37 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>pcl_recorder</name>
   <version>0.0.0</version>
   <description>The pcl_recorder package</description>
   <maintainer email="carla.simulator@gmail.com">CARLA Simulator Team</maintainer>
   <license>MIT</license>
-  <buildtool_depend>catkin</buildtool_depend>
+
+
+  <!-- ROS 1 DEPENDENCIES-->
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+  <build_depend condition="$ROS_VERSION == 1">roscpp</build_depend>
+  <build_depend condition="$ROS_VERSION == 1">roslaunch</build_depend>
+  <build_export_depend condition="$ROS_VERSION == 1">roscpp</build_export_depend>
+  <exec_depend condition="$ROS_VERSION == 1">roscpp</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 1">rostopic</exec_depend>
+
+  <!-- ROS 2 DEPENDENCIES-->
+  <depend condition="$ROS_VERSION == 2">rclcpp</depend>
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
+
   <build_depend>pcl_conversions</build_depend>
-  <build_depend>pcl_ros</build_depend>
-  <build_depend>roscpp</build_depend>
+  <!-- <build_depend>pcl_ros</build_depend> -->
   <build_depend>sensor_msgs</build_depend>
-  <build_depend>roslaunch</build_depend>
   <build_export_depend>pcl_conversions</build_export_depend>
-  <build_export_depend>pcl_ros</build_export_depend>
-  <build_export_depend>roscpp</build_export_depend>
+  <!-- <build_export_depend>pcl_ros</build_export_depend> -->
   <build_export_depend>sensor_msgs</build_export_depend>
   <exec_depend>pcl_conversions</exec_depend>
-  <exec_depend>pcl_ros</exec_depend>
-  <exec_depend>roscpp</exec_depend>
+  <!-- <exec_depend>pcl_ros</exec_depend> -->
   <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>rostopic</exec_depend>
   <exec_depend>carla_ros_bridge</exec_depend>
+  
   <export>
+    <build_type condition="$ROS_VERSION == 1">catkin</build_type>
+    <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
   </export>
 </package>

--- a/pcl_recorder/src/PclRecorderROS2.cpp
+++ b/pcl_recorder/src/PclRecorderROS2.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2019 Intel Corporation
+ *
+ * This work is licensed under the terms of the MIT license.
+ * For a copy, see <https://opensource.org/licenses/MIT>.
+ */
+#include "PclRecorderROS2.h"
+#include <string>
+#include <pcl/io/pcd_io.h>
+#include <sstream>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <pcl/common/transforms.h>
+
+PclRecorderROS2::PclRecorderROS2() : Node("pcl_recorder")
+{
+  rclcpp::Clock::SharedPtr clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  rclcpp::TimeSource timesource;
+  timesource.attachClock(clock);
+  tf_buffer_ = std::make_unique<tf2_ros::Buffer>(clock);
+
+  tfListener = new tf2_ros::TransformListener(*tf_buffer_);
+
+  if (mkdir("/tmp/pcl_capture", 0777) == -1) {
+    RCLCPP_WARN(this->get_logger(), "Could not create directory!");
+  }
+
+  // Create a ROS subscriber for the input point cloud
+  std::string roleName;
+  if (!this->get_parameter("role_name", roleName)) {
+    roleName = "ego_vehicle";
+  }
+  sub = this->create_subscription<sensor_msgs::msg::PointCloud2>("/carla/" + roleName + "/lidar/lidar1/point_cloud", 100, std::bind(&PclRecorderROS2::callback, this, std::placeholders::_1));
+}
+
+void PclRecorderROS2::callback(const sensor_msgs::msg::PointCloud2::SharedPtr cloud)
+{
+  if ((cloud->width * cloud->height) == 0) {
+    return;
+  }
+
+  std::stringstream ss;
+  ss << "/tmp/pcl_capture/capture" << cloud->header.stamp.sec << cloud->header.stamp.nanosec << ".pcd";
+
+
+  RCLCPP_INFO (this->get_logger(), "Received %d data points. Storing in %s",
+           (int)cloud->width * cloud->height,
+           ss.str().c_str());
+
+  Eigen::Affine3d transform;
+  try {
+    transform = tf2::transformToEigen (tf_buffer_->lookupTransform(fixed_frame_, cloud->header.frame_id,  cloud->header.stamp, rclcpp::Duration(1)));
+
+    pcl::PointCloud<pcl::PointXYZ> pclCloud;
+    pcl::fromROSMsg(*cloud, pclCloud);
+
+    pcl::PointCloud<pcl::PointXYZ> transformedCloud;
+    pcl::transformPointCloud (pclCloud, transformedCloud, transform);
+
+    pcl::PCDWriter writer;
+    writer.writeBinary(ss.str(), transformedCloud);
+  }
+  catch (tf2::TransformException &ex)
+  {
+    RCLCPP_WARN(this->get_logger(), "Could NOT transform: %s", ex.what());
+  }
+}

--- a/pcl_recorder/src/PclRecorderROS2.cpp
+++ b/pcl_recorder/src/PclRecorderROS2.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Intel Corporation
+ * Copyright (c) 2019-2020 Intel Corporation
  *
  * This work is licensed under the terms of the MIT license.
  * For a copy, see <https://opensource.org/licenses/MIT>.
@@ -8,7 +8,6 @@
 #include <string>
 #include <pcl/io/pcd_io.h>
 #include <sstream>
-#include <sensor_msgs/msg/point_cloud2.hpp>
 #include <pcl/common/transforms.h>
 
 PclRecorderROS2::PclRecorderROS2() : Node("pcl_recorder")

--- a/pcl_recorder/src/mainROS2.cpp
+++ b/pcl_recorder/src/mainROS2.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2019 Intel Corporation
+ *
+ * This work is licensed under the terms of the MIT license.
+ * For a copy, see <https://opensource.org/licenses/MIT>.
+ */
+#include "rclcpp/rclcpp.hpp"
+#include "PclRecorderROS2.h"
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<PclRecorderROS2>());
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
Ported pcl_recorder to ROS2:

- The separation between ROS1 and ROS2 is made in the CMakeList.txt file, two different sets of source code are used 
- The ROS2 code doesn't depend on pcl_ros (not available for ROS2) but directly on pcl

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/395)
<!-- Reviewable:end -->
