### PR TITLE
port of rqt plugin to ros2

### DIFF
--- a/carla_ros_bridge/launch/carla_ros_bridge.launch.py
+++ b/carla_ros_bridge/launch/carla_ros_bridge.launch.py
@@ -46,6 +46,7 @@ def generate_launch_description():
             node_executable='bridge',
             name='carla_ros_bridge',
             output='screen',
+            emulate_tty='True',
             on_exit=launch.actions.Shutdown(),
             parameters=[
                 {

--- a/carla_ros_bridge/launch/carla_ros_bridge_with_example_ego_vehicle.launch
+++ b/carla_ros_bridge/launch/carla_ros_bridge_with_example_ego_vehicle.launch
@@ -15,7 +15,7 @@
 
   <!-- Synchronous mode-->
   <arg name='synchronous_mode' default='False'/>
-  <arg name='synchronous_mode_wait_for_vehicle_control_command' default='True'/>
+  <arg name='synchronous_mode_wait_for_vehicle_control_command' default='False'/>
   <arg name='fixed_delta_seconds' default='0.05'/>
 
 

--- a/carla_ros_bridge/launch/carla_ros_bridge_with_example_ego_vehicle.launch.py
+++ b/carla_ros_bridge/launch/carla_ros_bridge_with_example_ego_vehicle.launch.py
@@ -42,7 +42,7 @@ def generate_launch_description():
         ),
         launch.actions.DeclareLaunchArgument(
             name='synchronous_mode_wait_for_vehicle_control_command',
-            default_value='True'
+            default_value='False'
         ),
         launch.actions.DeclareLaunchArgument(
             name='fixed_delta_seconds',

--- a/carla_ros_bridge/src/carla_ros_bridge/bridge.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/bridge.py
@@ -586,7 +586,7 @@ def main():
     parameters['timeout'] = carla_bridge.get_param('timeout', 2)
     parameters['synchronous_mode'] = carla_bridge.get_param('synchronous_mode', False)
     parameters['synchronous_mode_wait_for_vehicle_control_command'] = carla_bridge.get_param(
-        'synchronous_mode_wait_for_vehicle_control_command', True)
+        'synchronous_mode_wait_for_vehicle_control_command', False)
     parameters['fixed_delta_seconds'] = carla_bridge.get_param('fixed_delta_seconds',
                                                                0.05)
     parameters['town'] = carla_bridge.get_param('town', 'Town01')

--- a/rqt_carla_control/CMakeLists.txt
+++ b/rqt_carla_control/CMakeLists.txt
@@ -1,16 +1,34 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(rqt_carla_control)
 
-find_package(catkin REQUIRED COMPONENTS rospy rqt_gui_py roslaunch)
+find_package(ros_environment REQUIRED)
+set(ROS_VERSION $ENV{ROS_VERSION})
 
-catkin_python_setup()
+if(${ROS_VERSION} EQUAL 1)
 
-catkin_package(CATKIN_DEPENDS rospy rqt_gui_py)
+  find_package(catkin REQUIRED COMPONENTS rospy rqt_gui_py roslaunch)
 
-catkin_install_python(PROGRAMS src/rqt_carla_control/rqt_carla_control.py
-                      DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+  catkin_python_setup()
 
-install(DIRECTORY resource/
-        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/resource)
+  catkin_package(CATKIN_DEPENDS rospy rqt_gui_py)
 
-install(FILES plugin.xml DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+  catkin_install_python(PROGRAMS src/rqt_carla_control/rqt_carla_control.py
+                        DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+  install(DIRECTORY resource/
+          DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/resource)
+
+  install(FILES plugin.xml DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
+elseif(${ROS_VERSION} EQUAL 2)
+  find_package(ament_cmake REQUIRED)
+  find_package(rclpy REQUIRED)
+  ament_export_dependencies(rclpy)
+
+  install(DIRECTORY resource/
+          DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/resource)
+
+  install(FILES plugin.xml DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
+  ament_package()
+endif()

--- a/rqt_carla_control/package.xml
+++ b/rqt_carla_control/package.xml
@@ -1,16 +1,21 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>rqt_carla_control</name>
   <version>0.0.0</version>
   <description>The rqt_carla_control package</description>
   <maintainer email="carla.simulator@gmail.com">CARLA Simulator Team</maintainer>
   <license>MIT</license>
-  <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>rospy</build_depend>
+
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+  <build_depend condition="$ROS_VERSION == 1">rospy</build_depend>
   <build_depend>rqt_gui_py</build_depend>
-  <exec_depend>rospy</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 1">rospy</exec_depend>
   <exec_depend>rqt_gui_py</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 2">ament_index_python</exec_depend>
+  <exec_depend>python_qt_binding</exec_depend>
   <export>
+    <build_type condition="$ROS_VERSION == 1">catkin</build_type>
+    <build_type condition="$ROS_VERSION == 2">ament_python</build_type>
     <rqt_gui plugin="${prefix}/plugin.xml"/>
   </export>
 </package>

--- a/rqt_carla_control/setup.cfg
+++ b/rqt_carla_control/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script-dir=$base/lib/rqt_carla_control
+[install]
+install-scripts=$base/lib/rqt_carla_control

--- a/rqt_carla_control/setup.py
+++ b/rqt_carla_control/setup.py
@@ -1,15 +1,46 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 """
 Setup for rqt_carla_control
 """
+import os
+from glob import glob
+ROS_VERSION = int(os.environ['ROS_VERSION'])
 
-from distutils.core import setup
-from catkin_pkg.python_setup import generate_distutils_setup
+if ROS_VERSION == 1:
+    from distutils.core import setup
+    from catkin_pkg.python_setup import generate_distutils_setup
 
-d = generate_distutils_setup(
-    packages=['rqt_carla_control'],
-    package_dir={'': 'src'},
-)
+    d = generate_distutils_setup(
+        packages=['rqt_carla_control'],
+        package_dir={'': 'src'},
+    )
 
-setup(**d)
+    setup(**d)
+
+elif ROS_VERSION == 2:
+    from setuptools import setup
+
+    package_name = 'rqt_carla_control'
+    setup(
+        name=package_name,
+        version='0.0.0',
+        packages=[package_name],
+        package_dir={'': 'src'},
+        data_files=[
+            ('share/ament_index/resource_index/packages', ['resource/' + package_name]),
+            (os.path.join('share', package_name), ['package.xml']),
+            (os.path.join('share', package_name), ['plugin.xml']),
+            ('share/' + package_name + '/resource',
+             ['resource/CarlaControl.ui', 'resource/pause.png', 'resource/play.png', 'resource/step_once.png']),
+            ('lib/' + package_name, ['scripts/rqt_carla_control'])
+        ],
+        install_requires=['setuptools'],
+        zip_safe=True,
+        maintainer='CARLA Simulator Team',
+        maintainer_email='carla.simulator@gmail.com',
+        description='CARLA ROS2 RQT CONTROL',
+        license='MIT',
+        scripts=['scripts/rqt_carla_control'],
+    )

--- a/rqt_carla_control/src/rqt_carla_control/rqt_carla_control.py
+++ b/rqt_carla_control/src/rqt_carla_control/rqt_carla_control.py
@@ -9,8 +9,15 @@
 RQT Plugin to control CARLA
 """
 import os
-import rospy  # pylint: disable=import-error
-import rospkg
+
+ROS_VERSION = int(os.environ['ROS_VERSION'])
+if ROS_VERSION == 1:
+    import rospkg
+elif ROS_VERSION == 2:
+    from rclpy.callback_groups import ReentrantCallbackGroup
+    from ament_index_python.packages import get_package_share_directory
+    import threading
+from ros_compatibility import CompatibleNode, QoSProfile
 
 from qt_gui.plugin import Plugin  # pylint: disable=import-error
 from python_qt_binding import loadUi  # pylint: disable=import-error
@@ -34,8 +41,18 @@ class CarlaControlPlugin(Plugin):
         self.setObjectName('CARLA Control')
 
         self._widget = QWidget()
-        ui_file = os.path.join(rospkg.RosPack().get_path(
-            'rqt_carla_control'), 'resource', 'CarlaControl.ui')
+
+        self._node = CompatibleNode('rqt_carla_control_node', rospy_init=False)
+
+        if ROS_VERSION == 1:
+            package_share_dir = rospkg.RosPack().get_path('rqt_carla_control')
+            self.callback_group = None
+        elif ROS_VERSION == 2:
+            package_share_dir = get_package_share_directory('rqt_carla_control')
+            self.callback_group = ReentrantCallbackGroup()
+
+        ui_file = os.path.join(package_share_dir, 'resource', 'CarlaControl.ui')
+
         loadUi(ui_file, self._widget)
         self._widget.setObjectName('CarlaControl')
         if context.serial_number() > 1:
@@ -44,19 +61,20 @@ class CarlaControlPlugin(Plugin):
 
         self.pause_icon = QIcon(
             QPixmap(os.path.join(
-                rospkg.RosPack().get_path('rqt_carla_control'), 'resource', 'pause.png')))
+                package_share_dir, 'resource', 'pause.png')))
         self.play_icon = QIcon(
             QPixmap(os.path.join(
-                rospkg.RosPack().get_path('rqt_carla_control'), 'resource', 'play.png')))
+                package_share_dir, 'resource', 'play.png')))
         self._widget.pushButtonStepOnce.setIcon(
             QIcon(QPixmap(os.path.join(
-                rospkg.RosPack().get_path('rqt_carla_control'), 'resource', 'step_once.png'))))
+                package_share_dir, 'resource', 'step_once.png'))))
 
         self.carla_status = None
-        self.carla_status_subscriber = rospy.Subscriber(
-            "/carla/status", CarlaStatus, self.carla_status_changed)
-        self.carla_control_publisher = rospy.Publisher(
-            "/carla/control", CarlaControl, queue_size=10)
+        self.carla_status_subscriber = self._node.create_subscriber(
+            CarlaStatus, "/carla/status", self.carla_status_changed, callback_group=self.callback_group)
+
+        self.carla_control_publisher = self._node.new_publisher(
+            CarlaControl, "/carla/control", QoSProfile(depth=10, durability=False))
 
         self._widget.pushButtonPlayPause.setDisabled(True)
         self._widget.pushButtonStepOnce.setDisabled(True)
@@ -65,6 +83,10 @@ class CarlaControlPlugin(Plugin):
         self._widget.pushButtonStepOnce.clicked.connect(self.step_once)
 
         context.add_widget(self._widget)
+
+        if ROS_VERSION == 2:
+            spin_thread = threading.Thread(target=self._node.spin, daemon=True)
+            spin_thread.start()
 
     def toggle_play_pause(self):
         """
@@ -102,4 +124,4 @@ class CarlaControlPlugin(Plugin):
         """
         shutdown plugin
         """
-        self.carla_control_publisher.unregister()
+        self._node.destroy_subscription(self.carla_control_publisher)


### PR DESCRIPTION
Port of rqt_carla_control to ROS2.
- uses CompatibleNode for ROS1/ROS2 compatibility
- in ROS2, creates a thread to spin (there might be a more elegant way to do this)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/397)
<!-- Reviewable:end -->
