### PR TITLE
Fixed camera topic name

### DIFF
--- a/carla_ad_demo/config/carla_ad_demo.rviz
+++ b/carla_ad_demo/config/carla_ad_demo.rviz
@@ -80,7 +80,7 @@ Visualization Manager:
     - Class: rviz/Camera
       Enabled: true
       Image Rendering: background and overlay
-      Image Topic: /carla/ego_vehicle/camera/rgb/spectator_view/image_color
+      Image Topic: /carla/ego_vehicle/camera/rgb/view/image_color
       Name: Camera
       Overlay Alpha: 0.5
       Queue Size: 2


### PR DESCRIPTION
The Rviz configuration file was subscribed to the wrong camera topic name. Updated `SENSOR_ROLE_NAME` to `view`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/401)
<!-- Reviewable:end -->
