### PR TITLE
rviz_carla_plugin port to rviz2/ros2

### DIFF
--- a/carla_ad_demo/config/carla_ad_demo_ros2.rviz
+++ b/carla_ad_demo/config/carla_ad_demo_ros2.rviz
@@ -1,0 +1,168 @@
+Panels:
+  - Class: rviz_common/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+      Splitter Ratio: 0.5
+    Tree Height: 78
+  - Class: rviz_common/Selection
+    Name: Selection
+  - Class: rviz_common/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz_common/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz_carla_plugin/CarlaControl
+    Name: CarlaControl
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz_default_plugins/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 1
+      Buffer Length: 1
+      Class: rviz_default_plugins/Path
+      Color: 25; 255; 0
+      Enabled: true
+      Head Diameter: 0.30000001192092896
+      Head Length: 0.20000000298023224
+      Length: 0.30000001192092896
+      Line Style: Lines
+      Line Width: 0.029999999329447746
+      Name: Path
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Pose Color: 255; 85; 255
+      Pose Style: None
+      Radius: 0.029999999329447746
+      Shaft Diameter: 0.10000000149011612
+      Shaft Length: 0.10000000149011612
+      Topic: /carla/ego_vehicle/waypoints
+      Unreliable: false
+      Value: true
+    - Class: rviz_default_plugins/Camera
+      Enabled: true
+      Image Rendering: background and overlay
+      Topic: /carla/ego_vehicle/camera/rgb/spectator_view/image_color
+      Name: Camera
+      Overlay Alpha: 0.5
+      Queue Size: 2
+      Transport Hint: raw
+      Unreliable: false
+      Value: true
+      Visibility:
+        Grid: true
+        Marker: true
+        Path: true
+        Value: true
+      Zoom Factor: 1
+    - Class: rviz_default_plugins/Marker
+      Enabled: true
+      Topic: /carla/marker
+      Name: Marker
+      Namespaces:
+        "": true
+      Queue Size: 100
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: map
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz_default_plugins/Interact
+      Hide Inactive Objects: true
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/Select
+    - Class: rviz_default_plugins/FocusCamera
+    - Class: rviz_default_plugins/Measure
+    - Class: rviz_default_plugins/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz_default_plugins/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz_default_plugins/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz_default_plugins/ThirdPersonFollower
+      Distance: 13.610654830932617
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0
+        Y: 0
+        Z: 0
+      Focal Shape Fixed Size: false
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.49539870023727417
+      Target Frame: ego_vehicle
+      Value: ThirdPersonFollower (rviz_default_plugins)
+      Yaw: 3.1504008769989014
+    Saved: ~
+Window Geometry:
+  Camera:
+    collapsed: false
+  CarlaControl:
+    collapsed: false
+  Displays:
+    collapsed: false
+  Height: 1050
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd0000000400000000000001fe00000367fc020000000dfb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006800fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c0061007900730100000046000000e6000000e600fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d00610067006501000002870000001a0000000000000000fb0000000a0049006d00610067006501000002a70000001a0000000000000000fb0000000a0049006d00610067006501000002c70000001a0000000000000000fb0000000c00430061006d0065007200610100000132000001960000001a00fffffffb00000018004300610072006c00610043006f006e00740072006f006c01000002ce000000df000000df00ffffff000000010000010f00000367fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000004600000367000000be00fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000077e00000044fc0100000002fb0000000800540069006d006501000000000000077e000002e400fffffffb0000000800540069006d00650100000000000004500000000000000000000004650000036700000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1918
+  X: 0
+  Y: 27

--- a/carla_ad_demo/package.xml
+++ b/carla_ad_demo/package.xml
@@ -12,11 +12,10 @@
   <exec_depend>carla_waypoint_publisher</exec_depend>
   <exec_depend>carla_ad_agent</exec_depend>
   <exec_depend>carla_manual_control</exec_depend>
-  <!-- <exec_depend>rviz_carla_plugin</exec_depend> -->
+  <exec_depend>rviz_carla_plugin</exec_depend>
   <exec_depend>carla_twist_to_control</exec_depend>
-  <!-- <exec_depend>carla_spectator_camera</exec_depend> -->
-  <!-- <exec_depend>carla_ros_scenario_runner</exec_depend> -->
-  <exec_depend>rostopic</exec_depend>
+  <exec_depend>carla_spectator_camera</exec_depend>
+  <exec_depend>carla_ros_scenario_runner</exec_depend>
   
 
   <!-- ROS 2 DEPENDENCIES-->
@@ -26,6 +25,7 @@
   <!-- ROS 1 DEPENDENCIES-->
   <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
   <exec_depend condition="$ROS_VERSION == 1">rviz</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 1">rostopic</exec_depend>
 
   <export>
     <build_type condition="$ROS_VERSION == 1">catkin</build_type>

--- a/carla_ad_demo/setup.py
+++ b/carla_ad_demo/setup.py
@@ -27,7 +27,7 @@ elif ROS_VERSION == 2:
              ['resource/' + package_name]),
             ('share/' + package_name, ['package.xml']),
             ('share/' + package_name + '/config',
-             ['config/sensors.json']),
+             ['config/sensors.json', 'config/FollowLeadingVehicle.xosc', 'config/carla_ad_demo_ros2.rviz']),
             (os.path.join('share', package_name), glob('launch/*.launch.py'))
         ],
         install_requires=['setuptools'],

--- a/carla_ros_bridge/src/carla_ros_bridge/ego_vehicle.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/ego_vehicle.py
@@ -80,7 +80,7 @@ class EgoVehicle(Vehicle):
         self.control_override_subscriber = self.node.create_subscriber(
             Bool,
             self.get_topic_prefix() + "/vehicle_control_manual_override",
-            self.control_command_override)
+            self.control_command_override, QoSProfile(depth=1, durability=True))
 
         self.enable_autopilot_subscriber = self.node.create_subscriber(
             Bool,

--- a/carla_spectator_camera/CMakeLists.txt
+++ b/carla_spectator_camera/CMakeLists.txt
@@ -1,17 +1,34 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(carla_spectator_camera)
 
-find_package(catkin REQUIRED COMPONENTS rospy roslaunch geometry_msgs)
+find_package(ros_environment REQUIRED)
+set(ROS_VERSION $ENV{ROS_VERSION})
 
-catkin_python_setup()
+if(${ROS_VERSION} EQUAL 1)
 
-roslaunch_add_file_check(launch)
+  find_package(catkin REQUIRED COMPONENTS rospy roslaunch geometry_msgs)
 
-catkin_package(CATKIN_DEPENDS rospy)
+  catkin_python_setup()
 
-catkin_install_python(
-  PROGRAMS src/carla_spectator_camera/carla_spectator_camera.py DESTINATION
-  ${CATKIN_PACKAGE_BIN_DESTINATION})
+  roslaunch_add_file_check(launch)
 
-install(DIRECTORY launch/
-        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch)
+  catkin_package(CATKIN_DEPENDS rospy)
+
+  catkin_install_python(
+    PROGRAMS src/carla_spectator_camera/carla_spectator_camera.py DESTINATION
+    ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+  install(DIRECTORY launch/
+          DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch)
+
+elseif(${ROS_VERSION} EQUAL 2)
+  find_package(ament_cmake REQUIRED)
+  find_package(rclpy REQUIRED)
+  ament_export_dependencies(rclpy)
+
+  # Install launch files.
+  install(DIRECTORY launch DESTINATION share/${PROJECT_NAME}/)
+
+  ament_package()
+
+endif()

--- a/carla_spectator_camera/launch/carla_spectator_camera.launch.py
+++ b/carla_spectator_camera/launch/carla_spectator_camera.launch.py
@@ -40,15 +40,16 @@ def generate_launch_description():
             node_executable='carla_spectator_camera',
             name='carla_spectator_camera',
             output='screen',
+            emulate_tty='True',
             parameters=[
                 {
-                    '/carla/host': launch.substitutions.LaunchConfiguration('host')
+                    'carla/host': launch.substitutions.LaunchConfiguration('host')
                 },
                 {
-                    '/carla/port': launch.substitutions.LaunchConfiguration('port')
+                    'carla/port': launch.substitutions.LaunchConfiguration('port')
                 },
                 {
-                    '/carla/timeout': launch.substitutions.LaunchConfiguration('timeout')
+                    'carla/timeout': launch.substitutions.LaunchConfiguration('timeout')
                 },
                 {
                     'role_name': launch.substitutions.LaunchConfiguration('role_name')

--- a/carla_spectator_camera/package.xml
+++ b/carla_spectator_camera/package.xml
@@ -1,17 +1,27 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>carla_spectator_camera</name>
   <version>0.0.0</version>
   <description>The carla_spectator_camera package</description>
   <maintainer email="carla.simulator@gmail.com">CARLA Simulator Team</maintainer>
   <license>MIT</license>
-  <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>rospy</build_depend>
-  <build_depend>roslaunch</build_depend>
-  <build_export_depend>rospy</build_export_depend>
-  <exec_depend>rospy</exec_depend>
-  <exec_depend>topic_tools</exec_depend>
+
   <exec_depend>geometry_msgs</exec_depend>
-  <export>
+
+  <!-- ROS 1 DEPENDENCIES-->
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+  <build_depend condition="$ROS_VERSION == 1">rospy</build_depend>
+  <build_depend condition="$ROS_VERSION == 1">roslaunch</build_depend>
+  <build_export_depend condition="$ROS_VERSION == 1">rospy</build_export_depend>
+  <exec_depend condition="$ROS_VERSION == 1">rospy</exec_depend>
+  <exec_depend condition="$ROS_VERSION == 1">topic_tools</exec_depend>
+
+  <!-- ROS 2 DEPENDENCIES-->
+  <depend condition="$ROS_VERSION == 2">rclpy</depend>
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_python</buildtool_depend>
+  
+ <export>
+    <build_type condition="$ROS_VERSION == 1">catkin</build_type>
+    <build_type condition="$ROS_VERSION == 2">ament_python</build_type>
   </export>
 </package>

--- a/carla_spectator_camera/setup.cfg
+++ b/carla_spectator_camera/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script-dir=$base/lib/carla_spectator_camera
+[install]
+install-scripts=$base/lib/carla_spectator_camera

--- a/carla_spectator_camera/setup.py
+++ b/carla_spectator_camera/setup.py
@@ -1,13 +1,42 @@
 """
 Setup for carla_spectator_camera
 """
+import os
+from glob import glob
+ROS_VERSION = int(os.environ['ROS_VERSION'])
 
-from distutils.core import setup
-from catkin_pkg.python_setup import generate_distutils_setup
+if ROS_VERSION == 1:
+    from distutils.core import setup
+    from catkin_pkg.python_setup import generate_distutils_setup
 
-d = generate_distutils_setup(
-    packages=['carla_spectator_camera'],
-    package_dir={'': 'src'}
-)
+    d = generate_distutils_setup(
+        packages=['carla_spectator_camera'],
+        package_dir={'': 'src'}
+    )
 
-setup(**d)
+    setup(**d)
+
+elif ROS_VERSION == 2:
+    from setuptools import setup
+
+    package_name = 'carla_spectator_camera'
+    setup(
+        name=package_name,
+        version='0.0.0',
+        packages=[package_name],
+        data_files=[
+            ('share/ament_index/resource_index/packages', ['resource/' + package_name]),
+            (os.path.join('share', package_name), ['package.xml']),
+            (os.path.join('share', package_name), glob('launch/*.launch.py'))
+        ],
+        install_requires=['setuptools'],
+        zip_safe=True,
+        maintainer='CARLA Simulator Team',
+        maintainer_email='carla.simulator@gmail.com',
+        description='CARLA ROS2 Spectator Camera',
+        license='MIT',
+        entry_points={
+            'console_scripts': ['carla_spectator_camera = carla_spectator_camera.carla_spectator_camera:main'],
+        },
+        package_dir={'': 'src'},
+    )

--- a/carla_spectator_camera/src/carla_spectator_camera/carla_spectator_camera.py
+++ b/carla_spectator_camera/src/carla_spectator_camera/carla_spectator_camera.py
@@ -13,11 +13,20 @@ to /carla/<ROLENAME>/spectator_position.
 # pylint: disable=import-error
 import sys
 import math
-import rospy
-from tf.transformations import euler_from_quaternion
-import tf
 from geometry_msgs.msg import PoseStamped
 from carla_msgs.msg import CarlaWorldInfo
+
+from ros_compatibility import (
+    CompatibleNode,
+    euler_from_quaternion,
+    QoSProfile,
+    ROSException,
+    ROSInterruptException
+)
+import os
+ROS_VERSION = int(os.environ['ROS_VERSION'])
+if ROS_VERSION == 2:
+    import rclpy
 
 import carla
 
@@ -38,28 +47,27 @@ class CarlaSpectatorCamera(object):
         """
         Constructor
         """
-        rospy.init_node('spectator_camera', anonymous=True)
-        self.listener = tf.TransformListener()
-        self.role_name = rospy.get_param("/role_name", "ego_vehicle")
-        self.camera_resolution_x = rospy.get_param("~resolution_x", 800)
-        self.camera_resolution_y = rospy.get_param("~resolution_y", 600)
-        self.camera_fov = rospy.get_param("~fov", 50)
-        self.host = rospy.get_param('/carla/host', '127.0.0.1')
-        self.port = rospy.get_param('/carla/port', 2000)
-        self.timeout = rospy.get_param("/carla/timeout", 10)
+        self._node = CompatibleNode('spectator_camera')
+        self.role_name = self._node.get_param("role_name", "ego_vehicle")
+        self.camera_resolution_x = self._node.get_param("resolution_x", 800)
+        self.camera_resolution_y = self._node.get_param("resolution_y", 600)
+        self.camera_fov = self._node.get_param("fov", 50)
+        self.host = self._node.get_param('carla/host', '127.0.0.1')
+        self.port = self._node.get_param('carla/port', 2000)
+        self.timeout = self._node.get_param("carla/timeout", 10)
         self.world = None
         self.pose = None
         self.camera_actor = None
         self.ego_vehicle = None
-        rospy.Subscriber("/carla/{}/spectator_pose".format(self.role_name),
-                         PoseStamped, self.pose_received)
+        self._node.create_subscriber(PoseStamped,
+                                     "/carla/{}/spectator_pose".format(self.role_name), self.pose_received)
 
     def pose_received(self, pose):
         """
         Move the camera
         """
         if self.pose != pose:
-            rospy.logdebug("Camera pose changed. Updating carla camera")
+            self._node.logdebug("Camera pose changed. Updating carla camera")
             self.pose = pose
             transform = self.get_camera_transform()
             if transform and self.camera_actor:
@@ -70,10 +78,10 @@ class CarlaSpectatorCamera(object):
         Calculate the CARLA camera transform
         """
         if not self.pose:
-            rospy.loginfo("no pose!")
+            self._node.loginfo("no pose!")
             return None
         if self.pose.header.frame_id != self.role_name:
-            rospy.logwarn("Unsupported frame received. Supported {}, received {}".format(
+            self._node.logwarn("Unsupported frame received. Supported {}, received {}".format(
                 self.role_name, self.pose.header.frame_id))
             return None
         sensor_location = carla.Location(x=self.pose.pose.position.x,
@@ -100,7 +108,7 @@ class CarlaSpectatorCamera(object):
         try:
             bp = bp_library.find("sensor.camera.rgb")
             bp.set_attribute('role_name', "spectator_view")
-            rospy.loginfo("Creating camera with resolution {}x{}, fov {}".format(
+            self._node.loginfo("Creating camera with resolution {}x{}, fov {}".format(
                 self.camera_resolution_x,
                 self.camera_resolution_y,
                 self.camera_fov))
@@ -108,7 +116,7 @@ class CarlaSpectatorCamera(object):
             bp.set_attribute('image_size_y', str(self.camera_resolution_y))
             bp.set_attribute('fov', str(self.camera_fov))
         except KeyError as e:
-            rospy.logfatal("Camera could not be spawned: '{}'".format(e))
+            self._node.logfatal("Camera could not be spawned: '{}'".format(e))
         transform = self.get_camera_transform()
         if not transform:
             transform = carla.Transform()
@@ -137,7 +145,7 @@ class CarlaSpectatorCamera(object):
 
         if ego_vehicle_changed:
             self.destroy()
-            rospy.loginfo("Ego vehicle changed.")
+            self._node.loginfo("Ego vehicle changed.")
             self.ego_vehicle = hero
             if self.ego_vehicle:
                 self.create_camera(self.ego_vehicle)
@@ -155,24 +163,24 @@ class CarlaSpectatorCamera(object):
         main loop
         """
         # wait for ros-bridge to set up CARLA world
-        rospy.loginfo("Waiting for CARLA world (topic: /carla/world_info)...")
+        self._node.loginfo("Waiting for CARLA world (topic: /carla/world_info)...")
         try:
-            rospy.wait_for_message("/carla/world_info", CarlaWorldInfo, timeout=10.0)
-        except rospy.ROSException:
-            rospy.logerr("Error while waiting for world info!")
+            self._node.wait_for_one_message("/carla/world_info", CarlaWorldInfo, timeout=10.0,
+                                            qos_profile=QoSProfile(depth=10, durability=True))
+        except ROSException:
+            self._node.logerr("Error while waiting for world info!")
             sys.exit(1)
-        rospy.loginfo("CARLA world available. Waiting for ego vehicle...")
+        self._node.loginfo("CARLA world available. Waiting for ego vehicle...")
 
         client = carla.Client(self.host, self.port)
         client.set_timeout(self.timeout)
         self.world = client.get_world()
 
+        period = 0.1
         try:
-            r = rospy.Rate(10)  # 10hz
-            while not rospy.is_shutdown():
-                self.find_ego_vehicle_actor()
-                r.sleep()
-        except rospy.ROSInterruptException:
+            self._node.new_timer(period, lambda timer_event=None: self.find_ego_vehicle_actor())
+            self._node.spin()
+        except ROSInterruptException:
             pass
 
 # ==============================================================================
@@ -184,6 +192,9 @@ def main():
     """
     main function
     """
+    if ROS_VERSION == 2:
+        rclpy.init()
+
     carla_spectator_camera = CarlaSpectatorCamera()
     try:
         carla_spectator_camera.run()

--- a/carla_twist_to_control/CMakeLists.txt
+++ b/carla_twist_to_control/CMakeLists.txt
@@ -25,6 +25,10 @@ elseif(${ROS_VERSION} EQUAL 2)
   find_package(ament_cmake REQUIRED)
   find_package(rclpy REQUIRED)
   ament_export_dependencies(rclpy)
+
+  # Install launch files.
+  install(DIRECTORY launch DESTINATION share/${PROJECT_NAME}/)
+
   ament_package()
 
 endif()

--- a/carla_twist_to_control/launch/carla_twist_to_control.launch.py
+++ b/carla_twist_to_control/launch/carla_twist_to_control.launch.py
@@ -16,6 +16,7 @@ def generate_launch_description():
             node_executable='carla_twist_to_control',
             name=launch.substitutions.LaunchConfiguration('role_name'),
             output='screen',
+            emulate_tty='True',
             parameters=[
                 {
                     'role_name': launch.substitutions.LaunchConfiguration('role_name')

--- a/carla_twist_to_control/setup.py
+++ b/carla_twist_to_control/setup.py
@@ -3,6 +3,7 @@ Setup for carla_twist_to_control
 """
 
 import os
+from glob import glob
 ROS_VERSION = int(os.environ['ROS_VERSION'])
 
 if ROS_VERSION == 1:
@@ -26,6 +27,7 @@ elif ROS_VERSION == 2:
         packages=[package_name],
         data_files=[('share/ament_index/resource_index/packages', ['resource/' + package_name]),
                     ('share/' + package_name, ['package.xml']),
+                    (os.path.join('share', package_name), glob('launch/*.launch.py'))
                     ],
         install_requires=['setuptools'],
         zip_safe=True,
@@ -35,7 +37,7 @@ elif ROS_VERSION == 2:
         license='MIT',
         tests_require=['pytest'],
         entry_points={
-            'console_scripts': ['twist_to_control = carla_twist_to_control.carla_twist_to_control:main'],
+            'console_scripts': ['carla_twist_to_control = carla_twist_to_control.carla_twist_to_control:main'],
         },
         package_dir={'': 'src'},
     )

--- a/rviz_carla_plugin/CMakeLists.txt
+++ b/rviz_carla_plugin/CMakeLists.txt
@@ -1,40 +1,97 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.3)
 project(rviz_carla_plugin)
 
 set(CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 14)
 
-find_package(catkin REQUIRED COMPONENTS rviz carla_msgs nav_msgs
-                                        carla_ros_scenario_runner_types)
-catkin_package()
+find_package(ros_environment REQUIRED)
+set(ROS_VERSION $ENV{ROS_VERSION})
 
-include_directories(${catkin_INCLUDE_DIRS})
-link_directories(${catkin_LIBRARY_DIRS})
+if(${ROS_VERSION} EQUAL 1)
 
-set(CMAKE_AUTOMOC ON)
+  find_package(catkin REQUIRED COMPONENTS rviz carla_msgs nav_msgs
+                                          carla_ros_scenario_runner_types)
+  catkin_package()
 
-message(STATUS "Using Qt5 based on the rviz_QT_VERSION: ${rviz_QT_VERSION}")
-find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets)
-set(QT_LIBRARIES Qt5::Widgets)
+  include_directories(${catkin_INCLUDE_DIRS})
+  link_directories(${catkin_LIBRARY_DIRS})
 
-set(SRC_FILES src/drive_widget.cpp src/indicator_widget.cpp
-              src/carla_control_panel.cpp)
+  set(CMAKE_AUTOMOC ON)
 
-qt5_add_resources(SRC_FILES rviz_carla_plugin.qrc)
+  message(STATUS "Using Qt5 based on the rviz_QT_VERSION: ${rviz_QT_VERSION}")
+  find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets)
+  set(QT_LIBRARIES Qt5::Widgets)
 
-add_library(${PROJECT_NAME} ${SRC_FILES})
+  set(SRC_FILES src/drive_widget.cpp src/indicator_widget.cpp
+                src/carla_control_panel.cpp)
 
-target_link_libraries(${PROJECT_NAME} ${QT_LIBRARIES} ${catkin_LIBRARIES})
+  qt5_add_resources(SRC_FILES rviz_carla_plugin.qrc)
 
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
+  add_library(${PROJECT_NAME} ${SRC_FILES})
 
-install(
-  TARGETS ${PROJECT_NAME}
-  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+  target_link_libraries(${PROJECT_NAME} ${QT_LIBRARIES} ${catkin_LIBRARIES})
 
-install(FILES plugin_description.xml
-        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+  target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
 
-install(DIRECTORY icons/ DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/icons)
+  install(
+    TARGETS ${PROJECT_NAME}
+    ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+
+  install(FILES plugin_description.xml
+          DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+
+  install(DIRECTORY icons/
+          DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/icons)
+
+elseif(${ROS_VERSION} EQUAL 2)
+
+  find_package(ament_cmake REQUIRED)
+  find_package(rviz_common REQUIRED)
+  find_package(carla_msgs REQUIRED)
+  find_package(nav_msgs COMPONENTS)
+  find_package(carla_ros_scenario_runner_types COMPONENTS)
+  find_package(pluginlib REQUIRED)
+  find_package(rviz_ogre_vendor REQUIRED)
+
+  set(CMAKE_AUTOMOC ON)
+
+  message(STATUS "Using Qt5 based on the rviz_QT_VERSION: ${rviz_QT_VERSION}")
+  find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets)
+  set(QT_LIBRARIES Qt5::Widgets)
+
+  set(SRC_FILES src/drive_widget.cpp src/indicator_widget.cpp
+                src/carla_control_panel_ROS2.cpp)
+
+  qt5_add_resources(SRC_FILES rviz_carla_plugin.qrc)
+
+  add_library(${PROJECT_NAME} SHARED ${SRC_FILES})
+
+  target_link_libraries(${PROJECT_NAME} ${QT_LIBRARIES}
+                        rviz_ogre_vendor::OgreMain)
+
+  target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
+
+  pluginlib_export_plugin_description_file(rviz_common
+                                           plugin_description_ros2.xml)
+
+  ament_target_dependencies(rviz_carla_plugin rclcpp carla_msgs nav_msgs
+                            carla_ros_scenario_runner_types)
+
+  ament_export_libraries(${PROJECT_NAME})
+
+  install(
+    TARGETS ${PROJECT_NAME}
+    EXPORT ${PROJECT_NAME}
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin)
+
+  install(FILES plugin_description_ros2.xml DESTINATION "share/${PROJECT_NAME}")
+
+  install(DIRECTORY icons/ DESTINATION "share/${PROJECT_NAME}")
+
+  ament_package()
+
+endif()

--- a/rviz_carla_plugin/package.xml
+++ b/rviz_carla_plugin/package.xml
@@ -1,26 +1,37 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>rviz_carla_plugin</name>
   <version>0.0.1</version>
   <description>The carla_ros_bridge package</description>
   <maintainer email="carla.simulator@gmail.com">CARLA Simulator Team</maintainer>
   <license>MIT</license>
-  <buildtool_depend>catkin</buildtool_depend>
+
+  <!-- ROS 1 DEPENDENCIES-->
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+  <build_depend condition="$ROS_VERSION == 1">rviz</build_depend>
+  <exec_depend condition="$ROS_VERSION == 1">rviz</exec_depend>
+
+  <!-- ROS 2 DEPENDENCIES-->
+  <depend condition="$ROS_VERSION == 2">rclcpp</depend>
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
+  <depend condition="$ROS_VERSION == 2">rviz_common</depend>
+
   <build_depend>qtbase5-dev</build_depend>
-  <build_depend>rviz</build_depend>
-  <build_depend>carla_msgs</build_depend>
+  <depend>carla_msgs</depend>
   <build_depend>nav_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>carla_ros_scenario_runner_types</build_depend>
-  <exec_depend>carla_msgs</exec_depend>
   <exec_depend>nav_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>carla_ros_scenario_runner_types</exec_depend>
   <exec_depend>libqt5-core</exec_depend>
   <exec_depend>libqt5-gui</exec_depend>
   <exec_depend>libqt5-widgets</exec_depend>
-  <exec_depend>rviz</exec_depend>
+  
   <export>
-      <rviz plugin="${prefix}/plugin_description.xml"/>
+      <rviz condition="$ROS_VERSION == 1" plugin="${prefix}/plugin_description.xml"/>
+      <rviz condition="$ROS_VERSION == 2" plugin="${prefix}/plugin_description_ros2.xml"/>
+      <build_type condition="$ROS_VERSION == 1">catkin</build_type>
+      <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
   </export>
 </package>

--- a/rviz_carla_plugin/plugin_description_ros2.xml
+++ b/rviz_carla_plugin/plugin_description_ros2.xml
@@ -1,0 +1,9 @@
+<library path="rviz_carla_plugin">
+  <class name="rviz_carla_plugin/CarlaControl"
+         type="rviz_carla_plugin::CarlaControlPanel"
+         base_class_type="rviz_common::Panel">
+    <description>
+      A panel widget for controlling carla nodes
+    </description>
+  </class>
+</library>

--- a/rviz_carla_plugin/src/carla_control_panel_ROS2.cpp
+++ b/rviz_carla_plugin/src/carla_control_panel_ROS2.cpp
@@ -1,0 +1,411 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * This work is licensed under the terms of the MIT license.
+ * For a copy, see <https://opensource.org/licenses/MIT>.
+ */
+#include <QCheckBox>
+#include <QComboBox>
+#include <QFormLayout>
+#include <QHBoxLayout>
+#include <QIcon>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPainter>
+#include <QPixmap>
+#include <QProgressBar>
+#include <QPushButton>
+#include <QTimer>
+#include <QVBoxLayout>
+#include <cstdio>
+
+#include <carla_msgs/CarlaControl.h>
+#include <carla_ros_scenario_runner_types/ExecuteScenario.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/Twist.h>
+#include <std_msgs/Bool.h>
+#include <tf/transform_datatypes.h>
+
+#include <OgreCamera.h>
+#include <OgreVector3.h>
+#include <rviz/frame_position_tracking_view_controller.h>
+#include <rviz/view_manager.h>
+#include <rviz/visualization_manager.h>
+#include "carla_control_panel.h"
+#include "drive_widget.h"
+#include "indicator_widget.h"
+
+namespace rviz_carla_plugin {
+
+CarlaControlPanel::CarlaControlPanel(QWidget *parent)
+  : rviz::Panel(parent)
+{
+  QVBoxLayout *layout = new QVBoxLayout;
+  QHBoxLayout *vehicleLayout = new QHBoxLayout;
+
+  QFormLayout *egoCtrlStatusLayout = new QFormLayout;
+
+  mThrottleBar = new QProgressBar();
+  mThrottleBar->setRange(0, 100);
+  egoCtrlStatusLayout->addRow("Throttle", mThrottleBar);
+  mBrakeBar = new QProgressBar();
+  mBrakeBar->setRange(0, 100);
+  egoCtrlStatusLayout->addRow("Brake", mBrakeBar);
+  mSteerBar = new QProgressBar();
+  mSteerBar->setRange(-100, 100);
+  egoCtrlStatusLayout->addRow("Steer", mSteerBar);
+  vehicleLayout->addLayout(egoCtrlStatusLayout);
+
+  QFormLayout *egoStatusLayout = new QFormLayout;
+  mPosLabel = new QLineEdit();
+  mPosLabel->setDisabled(true);
+  egoStatusLayout->addRow("Position", mPosLabel);
+
+  mSpeedLabel = new QLineEdit();
+  mSpeedLabel->setDisabled(true);
+  egoStatusLayout->addRow("Speed", mSpeedLabel);
+
+  mHeadingLabel = new QLineEdit();
+  mHeadingLabel->setDisabled(true);
+  egoStatusLayout->addRow("Heading", mHeadingLabel);
+
+  vehicleLayout->addLayout(egoStatusLayout);
+
+  QVBoxLayout *egoCtrlLayout = new QVBoxLayout;
+  mOverrideVehicleControl = new QCheckBox("Manual control");
+  mOverrideVehicleControl->setDisabled(true);
+  egoCtrlLayout->addWidget(mOverrideVehicleControl);
+  mDriveWidget = new DriveWidget;
+  mDriveWidget->setDisabled(true);
+  egoCtrlLayout->addWidget(mDriveWidget);
+  connect(mOverrideVehicleControl, SIGNAL(stateChanged(int)), this, SLOT(overrideVehicleControl(int)));
+
+  vehicleLayout->addLayout(egoCtrlLayout);
+
+  layout->addLayout(vehicleLayout);
+
+  QFormLayout *carlaLayout = new QFormLayout;
+
+  // row1
+  QHBoxLayout *carlaRow1Layout = new QHBoxLayout;
+
+  mScenarioSelection = new QComboBox();
+  carlaRow1Layout->addWidget(mScenarioSelection, 10);
+
+  mTriggerScenarioButton = new QPushButton("Execute");
+  carlaRow1Layout->addWidget(mTriggerScenarioButton);
+
+  mIndicatorWidget = new IndicatorWidget();
+  carlaRow1Layout->addWidget(mIndicatorWidget);
+  connect(mTriggerScenarioButton, SIGNAL(released()), this, SLOT(executeScenario()));
+
+  carlaLayout->addRow("Scenario Execution", carlaRow1Layout);
+
+  QHBoxLayout *synchronous_layout = new QHBoxLayout;
+  QPixmap pixmap(":/icons/play.png");
+  QIcon iconPlay(pixmap);
+  mPlayPauseButton = new QPushButton(iconPlay, "");
+  synchronous_layout->addWidget(mPlayPauseButton);
+  connect(mPlayPauseButton, SIGNAL(released()), this, SLOT(carlaTogglePlayPause()));
+
+  QPixmap pixmapStepOnce(":/icons/step_once.png");
+  QIcon iconStepOnce(pixmapStepOnce);
+  mStepOnceButton = new QPushButton(iconStepOnce, "");
+  connect(mStepOnceButton, SIGNAL(released()), this, SLOT(carlaStepOnce()));
+
+  synchronous_layout->addWidget(mStepOnceButton);
+  carlaLayout->addRow("Carla Control", synchronous_layout);
+
+  layout->addLayout(carlaLayout);
+
+  setLayout(layout);
+
+  QTimer *outputTimer = new QTimer(this);
+  connect(outputTimer, SIGNAL(timeout()), this, SLOT(sendVel()));
+  outputTimer->start(100);
+
+  connect(mDriveWidget, SIGNAL(outputVelocity(float, float)), this, SLOT(setVel(float, float)));
+  mDriveWidget->setEnabled(false);
+
+  setSimulationButtonStatus(false);
+  setScenarioRunnerStatus(false);
+
+  mCarlaStatusSubscriber = mNodeHandle.subscribe("/carla/status", 1000, &CarlaControlPanel::carlaStatusChanged, this);
+  mCarlaControlPublisher = mNodeHandle.advertise<carla_msgs::CarlaControl>("/carla/control", 10);
+  mEgoVehicleStatusSubscriber = mNodeHandle.subscribe(
+    "/carla/ego_vehicle/vehicle_status", 1000, &CarlaControlPanel::egoVehicleStatusChanged, this);
+  mEgoVehicleOdometrySubscriber
+    = mNodeHandle.subscribe("/carla/ego_vehicle/odometry", 1000, &CarlaControlPanel::egoVehicleOdometryChanged, this);
+
+  mCameraPosePublisher
+    = mNodeHandle.advertise<geometry_msgs::PoseStamped>("carla/ego_vehicle/spectator_pose", 10, true);
+
+  mEgoVehicleControlManualOverridePublisher
+    = mNodeHandle.advertise<std_msgs::Bool>("/carla/ego_vehicle/vehicle_control_manual_override", 1, true);
+
+  mExecuteScenarioClient
+    = mNodeHandle.serviceClient<carla_ros_scenario_runner_types::ExecuteScenario>("/scenario_runner/execute_scenario");
+  mScenarioRunnerStatusSubscriber
+    = mNodeHandle.subscribe("/scenario_runner/status", 10, &CarlaControlPanel::scenarioRunnerStatusChanged, this);
+
+  mTwistPublisher = mNodeHandle.advertise<geometry_msgs::Twist>("/carla/ego_vehicle/twist", 1);
+
+  mScenarioSubscriber
+    = mNodeHandle.subscribe("/carla/available_scenarios", 1, &CarlaControlPanel::carlaScenariosChanged, this);
+
+  // //initially set the camera
+  QTimer::singleShot(1000, this, SLOT(updateCameraPos()));
+}
+
+void CarlaControlPanel::cameraPreRenderScene(Ogre::Camera *cam)
+{
+  double epsilon = 0.001;
+  if ((std::fabs(cam->getPosition().x - mCameraCurrentPosition.x) > epsilon)
+      || (std::fabs(cam->getPosition().y - mCameraCurrentPosition.y) > epsilon)
+      || (std::fabs(cam->getPosition().z - mCameraCurrentPosition.z) > epsilon)
+      || (std::fabs(cam->getOrientation().x - mCameraCurrentOrientation.x) > epsilon)
+      || (std::fabs(cam->getOrientation().y - mCameraCurrentOrientation.y) > epsilon)
+      || (std::fabs(cam->getOrientation().z - mCameraCurrentOrientation.z) > epsilon)
+      || (std::fabs(cam->getOrientation().w - mCameraCurrentOrientation.w) > epsilon))
+  {
+    mCameraCurrentPosition = cam->getPosition();
+    mCameraCurrentOrientation = cam->getOrientation();
+    QTimer::singleShot(0, this, SLOT(updateCameraPos()));
+  }
+}
+
+void CarlaControlPanel::updateCameraPos()
+{
+  auto frame = mViewController->subProp("Target Frame")->getValue();
+
+  geometry_msgs::PoseStamped pose;
+  pose.header.frame_id = frame.toString().toStdString();
+  pose.header.stamp = ros::Time::now();
+  pose.pose.position.x = mCameraCurrentPosition.x;
+  pose.pose.position.y = mCameraCurrentPosition.y;
+  pose.pose.position.z = mCameraCurrentPosition.z;
+  pose.pose.orientation.x = mCameraCurrentOrientation.x;
+  pose.pose.orientation.y = mCameraCurrentOrientation.y;
+  pose.pose.orientation.z = mCameraCurrentOrientation.z;
+  pose.pose.orientation.w = mCameraCurrentOrientation.w;
+
+  mCameraPosePublisher.publish(pose);
+}
+
+void CarlaControlPanel::onInitialize()
+{
+  currentViewControllerChanged();
+  connect(vis_manager_->getViewManager(), SIGNAL(currentChanged()), this, SLOT(currentViewControllerChanged()));
+}
+
+void CarlaControlPanel::currentViewControllerChanged()
+{
+  mViewController
+    = dynamic_cast<rviz::FramePositionTrackingViewController *>(vis_manager_->getViewManager()->getCurrent());
+  if (!mViewController)
+  {
+    ROS_ERROR("Invalid view controller!");
+    return;
+  }
+
+  auto camera = mViewController->getCamera();
+  camera->addListener(this);
+}
+
+void CarlaControlPanel::executeScenario()
+{
+  for (auto const &scenario : mCarlaScenarios->scenarios)
+  {
+    if (QString::fromStdString(scenario.name) == mScenarioSelection->currentText())
+    {
+      carla_ros_scenario_runner_types::ExecuteScenario srv;
+      srv.request.scenario = scenario;
+      if (!mExecuteScenarioClient.call(srv))
+      {
+        ROS_ERROR("Failed to call service executeScenario");
+        mIndicatorWidget->setState(IndicatorWidget::State::Error);
+      }
+      break;
+    }
+  }
+}
+
+void CarlaControlPanel::overrideVehicleControl(int state)
+{
+  std_msgs::Bool boolMsg;
+  if (state == Qt::Checked)
+  {
+    boolMsg.data = true;
+    mDriveWidget->setEnabled(true);
+  }
+  else
+  {
+    boolMsg.data = false;
+    mDriveWidget->setEnabled(false);
+  }
+  mEgoVehicleControlManualOverridePublisher.publish(boolMsg);
+}
+
+void CarlaControlPanel::scenarioRunnerStatusChanged(
+  const carla_ros_scenario_runner_types::CarlaScenarioRunnerStatus::ConstPtr &msg)
+{
+  if (msg->status == carla_ros_scenario_runner_types::CarlaScenarioRunnerStatus::STOPPED)
+  {
+    mIndicatorWidget->setState(IndicatorWidget::State::Stopped);
+  }
+  else if (msg->status == carla_ros_scenario_runner_types::CarlaScenarioRunnerStatus::STARTING)
+  {
+    mIndicatorWidget->setState(IndicatorWidget::State::Starting);
+  }
+  else if (msg->status == carla_ros_scenario_runner_types::CarlaScenarioRunnerStatus::RUNNING)
+  {
+    mIndicatorWidget->setState(IndicatorWidget::State::Running);
+  }
+  else if (msg->status == carla_ros_scenario_runner_types::CarlaScenarioRunnerStatus::SHUTTINGDOWN)
+  {
+    mIndicatorWidget->setState(IndicatorWidget::State::ShuttingDown);
+  }
+  else
+  {
+    mIndicatorWidget->setState(IndicatorWidget::State::Error);
+  }
+}
+
+void CarlaControlPanel::setScenarioRunnerStatus(bool active)
+{
+  mScenarioSelection->setEnabled(active);
+  mTriggerScenarioButton->setEnabled(active);
+  mIndicatorWidget->setEnabled(active);
+}
+
+void CarlaControlPanel::carlaScenariosChanged(const carla_ros_scenario_runner_types::CarlaScenarioList::ConstPtr &msg)
+{
+  auto currentSelection = mScenarioSelection->currentText();
+  mCarlaScenarios = msg;
+  mScenarioSelection->clear();
+  int idx = 0;
+  for (auto const &scenario : msg->scenarios)
+  {
+    auto name = QString::fromStdString(scenario.name);
+    mScenarioSelection->addItem(name);
+    if (name == currentSelection)
+    { // switch to previously selected item
+      mScenarioSelection->setCurrentIndex(idx);
+    }
+    ++idx;
+  }
+  setScenarioRunnerStatus(mScenarioSelection->count() > 0);
+}
+
+void CarlaControlPanel::egoVehicleStatusChanged(const carla_msgs::CarlaEgoVehicleStatus::ConstPtr &msg)
+{
+  mOverrideVehicleControl->setEnabled(true);
+  mSteerBar->setValue(msg->control.steer * 100);
+  mThrottleBar->setValue(msg->control.throttle * 100);
+  mBrakeBar->setValue(msg->control.brake * 100);
+
+  std::stringstream speedStream;
+  speedStream << std::fixed << std::setprecision(2) << msg->velocity * 3.6;
+  mSpeedLabel->setText(speedStream.str().c_str());
+}
+
+void CarlaControlPanel::egoVehicleOdometryChanged(const nav_msgs::Odometry::ConstPtr &msg)
+{
+  std::stringstream posStream;
+  posStream << std::fixed << std::setprecision(2) << msg->pose.pose.position.x << ", " << msg->pose.pose.position.y;
+  mPosLabel->setText(posStream.str().c_str());
+
+  std::stringstream headingStream;
+  headingStream << std::fixed << std::setprecision(2) << tf::getYaw(msg->pose.pose.orientation);
+  mHeadingLabel->setText(headingStream.str().c_str());
+}
+
+void CarlaControlPanel::setSimulationButtonStatus(bool active)
+{
+  if (active)
+  {
+    mPlayPauseButton->setDisabled(false);
+    mPlayPauseButton->setToolTip("Play/Pause the CARLA world.");
+    mStepOnceButton->setDisabled(false);
+    mStepOnceButton->setToolTip("Execute on tick within the CARLA world.");
+  }
+  else
+  {
+    mPlayPauseButton->setDisabled(true);
+    mPlayPauseButton->setToolTip("Disabled due to CARLA running in non-synchronous mode.");
+    mStepOnceButton->setDisabled(true);
+    mStepOnceButton->setToolTip("Disabled due to CARLA running in non-synchronous mode.");
+  }
+}
+
+void CarlaControlPanel::carlaStatusChanged(const carla_msgs::CarlaStatus::ConstPtr &msg)
+{
+  mCarlaStatus = msg;
+  setSimulationButtonStatus(mCarlaStatus->synchronous_mode);
+
+  if (mCarlaStatus->synchronous_mode)
+  {
+    if (mCarlaStatus->synchronous_mode_running)
+    {
+      QPixmap pixmap(":/icons/pause.png");
+      QIcon iconPause(pixmap);
+      mPlayPauseButton->setIcon(iconPause);
+    }
+    else
+    {
+      QPixmap pixmap(":/icons/play.png");
+      QIcon iconPlay(pixmap);
+      mPlayPauseButton->setIcon(iconPlay);
+    }
+  }
+}
+
+void CarlaControlPanel::carlaStepOnce()
+{
+  carla_msgs::CarlaControl ctrl;
+  ctrl.command = carla_msgs::CarlaControl::STEP_ONCE;
+  mCarlaControlPublisher.publish(ctrl);
+}
+
+void CarlaControlPanel::carlaTogglePlayPause()
+{
+  if (mCarlaStatus)
+  {
+    carla_msgs::CarlaControl ctrl;
+    if (mCarlaStatus->synchronous_mode_running)
+    {
+      ctrl.command = carla_msgs::CarlaControl::PAUSE;
+    }
+    else
+    {
+      ctrl.command = carla_msgs::CarlaControl::PLAY;
+    }
+    mCarlaControlPublisher.publish(ctrl);
+  }
+}
+
+void CarlaControlPanel::setVel(float linearVelocity, float angularVelocity)
+{
+  mLinearVelocity = linearVelocity;
+  mAngularVelocity = angularVelocity;
+}
+
+void CarlaControlPanel::sendVel()
+{
+  if (ros::ok() && mTwistPublisher && (mOverrideVehicleControl->checkState() == Qt::Checked))
+  {
+    geometry_msgs::Twist msg;
+    msg.linear.x = mLinearVelocity;
+    msg.linear.y = 0;
+    msg.linear.z = 0;
+    msg.angular.x = 0;
+    msg.angular.y = 0;
+    msg.angular.z = mAngularVelocity;
+    mTwistPublisher.publish(msg);
+  }
+}
+
+} // end namespace rviz_carla_plugin
+
+#include <pluginlib/class_list_macros.h>
+PLUGINLIB_EXPORT_CLASS(rviz_carla_plugin::CarlaControlPanel, rviz::Panel)

--- a/rviz_carla_plugin/src/carla_control_panel_ROS2.h
+++ b/rviz_carla_plugin/src/carla_control_panel_ROS2.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * This work is licensed under the terms of the MIT license.
+ * For a copy, see <https://opensource.org/licenses/MIT>.
+ */
+#pragma once
+
+#include <OgreCamera.h>
+#include <carla_msgs/CarlaEgoVehicleStatus.h>
+#include <carla_msgs/CarlaStatus.h>
+#include <carla_ros_scenario_runner_types/CarlaScenarioList.h>
+#include <carla_ros_scenario_runner_types/CarlaScenarioRunnerStatus.h>
+#include <nav_msgs/Odometry.h>
+#include <ros/ros.h>
+#include <rviz/panel.h>
+
+class QLineEdit;
+class QPushButton;
+class QProgressBar;
+class QCheckBox;
+class QComboBox;
+
+namespace rviz {
+class ViewController;
+class FramePositionTrackingViewController;
+}
+
+namespace rviz_carla_plugin {
+
+class DriveWidget;
+class IndicatorWidget;
+
+class CarlaControlPanel : public rviz::Panel, public Ogre::Camera::Listener
+{
+  Q_OBJECT
+public:
+  CarlaControlPanel(QWidget *parent = 0);
+
+public Q_SLOTS:
+  void setVel(float linearVelocity, float angularVelocity);
+
+protected Q_SLOTS:
+  void sendVel();
+
+  void carlaStepOnce();
+  void carlaTogglePlayPause();
+  void overrideVehicleControl(int state);
+  void executeScenario();
+
+  void updateCameraPos();
+  void currentViewControllerChanged();
+
+protected:
+  virtual void cameraPreRenderScene(Ogre::Camera *cam) override;
+
+  virtual void onInitialize() override;
+  void setSimulationButtonStatus(bool active);
+  void setScenarioRunnerStatus(bool active);
+
+  void scenarioRunnerStatusChanged(const carla_ros_scenario_runner_types::CarlaScenarioRunnerStatus::ConstPtr &msg);
+  void carlaStatusChanged(const carla_msgs::CarlaStatus::ConstPtr &msg);
+  void egoVehicleStatusChanged(const carla_msgs::CarlaEgoVehicleStatus::ConstPtr &msg);
+  void egoVehicleOdometryChanged(const nav_msgs::Odometry::ConstPtr &msg);
+  void carlaScenariosChanged(const carla_ros_scenario_runner_types::CarlaScenarioList::ConstPtr &msg);
+  carla_msgs::CarlaStatus::ConstPtr mCarlaStatus{nullptr};
+
+  DriveWidget *mDriveWidget;
+  QPushButton *mTriggerScenarioButton;
+  QPushButton *mPlayPauseButton;
+  QPushButton *mStepOnceButton;
+  QProgressBar *mThrottleBar;
+  QProgressBar *mBrakeBar;
+  QProgressBar *mSteerBar;
+  QLineEdit *mPosLabel;
+  QLineEdit *mSpeedLabel;
+  QLineEdit *mHeadingLabel;
+  QCheckBox *mOverrideVehicleControl;
+  QComboBox *mScenarioSelection;
+  IndicatorWidget *mIndicatorWidget;
+  ros::Publisher mTwistPublisher;
+  ros::Publisher mCarlaControlPublisher;
+  ros::Publisher mEgoVehicleControlManualOverridePublisher;
+  ros::Subscriber mCarlaStatusSubscriber;
+  ros::Subscriber mEgoVehicleStatusSubscriber;
+  ros::Subscriber mEgoVehicleOdometrySubscriber;
+  ros::ServiceClient mExecuteScenarioClient;
+  ros::Subscriber mScenarioSubscriber;
+  ros::Subscriber mScenarioRunnerStatusSubscriber;
+  ros::Publisher mCameraPosePublisher;
+
+  carla_ros_scenario_runner_types::CarlaScenarioList::ConstPtr mCarlaScenarios;
+
+  ros::NodeHandle mNodeHandle;
+
+  float mLinearVelocity{0.0};
+  float mAngularVelocity{0.0};
+  bool mVehicleControlManualOverride{false};
+  rviz::FramePositionTrackingViewController *mViewController{nullptr};
+  Ogre::Vector3 mCameraCurrentPosition;
+  Ogre::Quaternion mCameraCurrentOrientation;
+};
+
+} // end namespace rviz_carla_plugin


### PR DESCRIPTION
Port of the rviz_carla_plugin to rviz/ros2:

The main source files that define the carla panel (_carla_control_panel.cpp/h_) remain unchanged, but when using ROS2, the CMakelists.txt uses the new files _carla_control_panel_ROS2.cpp/h_ to build the plugin library.

The only thing missing when using this with ros2, is the Time panel in rviz2, that was used in ros1 to display simulation time, real time, etc... This plugin is not available in the eloquent rviz2 library, but it probably will be in future distributions, as I saw it was already implemented in the master branch.

Apart from that, running scenarios, moving the spectator camera, and using the DriveWidget to manually control the ego vehicle should work. I also finished to configure the carla_ad_demo package, so the carla_ad_demo_with_scenario_launch.py launchfile should work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/403)
<!-- Reviewable:end -->
