### PR TITLE
Pylint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,7 @@ jobs:
         catkin run_tests --no-status --force-color && catkin_test_results
         source devel/setup.bash
         cd $GITHUB_WORKSPACE
-      #  make pylint
-      # TODO enable pylint
+        if [ "${{ matrix.ros-version }}" = "melodic" ] ; then make pylint ; fi
 
   debian:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ build.gradle
 # IDE
 .vscode
 .idea
+
+venv

--- a/carla_ros_scenario_runner/src/carla_ros_scenario_runner/carla_ros_scenario_runner.py
+++ b/carla_ros_scenario_runner/src/carla_ros_scenario_runner/carla_ros_scenario_runner.py
@@ -10,6 +10,7 @@ Execute scenarios via ros service
 
 Internally, the CARLA scenario runner is executed
 """
+from __future__ import print_function
 import sys
 import os
 try:


### PR DESCRIPTION
Somehow pylint was disabled in the CI, so I enabled it for melodic (python2) and fixed all errors.

One thing I realized during fixing the pylint issues was the insufficient work of autopep8. There were several warnings that the line lenght was too long. Actually this should be the job of a formatter but somehow autopep8 is not that greedy here. What is you opinion to changing the code formatter to [yapf](https://github.com/google/yapf) or [black](https://github.com/psf/black)?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/428)
<!-- Reviewable:end -->
