### PR TITLE
added option to change pose of camera at runtime by publishing on topic

### DIFF
--- a/carla_ros_bridge/src/carla_ros_bridge/actor_factory.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/actor_factory.py
@@ -121,7 +121,7 @@ class ActorFactory(object):
             name = str(carla_actor.id)
         return self.create(carla_actor.type_id, name, parent_id, None, carla_actor)
 
-    def create(self, type_id, name, attach_to, spawn_pose, carla_actor=None):
+    def create(self, type_id, name, attach_to, spawn_pose, carla_actor=None, allow_transform=False):
         with self.lock:
             # check that the actor is not already created.
             if carla_actor is not None and carla_actor.id in self.actors:
@@ -139,7 +139,8 @@ class ActorFactory(object):
             else:
                 uid = next(self.id_gen)
 
-            actor = self._create_object(uid, type_id, name, parent, spawn_pose, carla_actor)
+            actor = self._create_object(uid, type_id, name, parent,
+                                        spawn_pose, carla_actor, allow_transform=allow_transform)
             self.actors[actor.uid] = actor
 
             rospy.loginfo("Created {}(id={})".format(actor.__class__.__name__, actor.uid))
@@ -169,7 +170,7 @@ class ActorFactory(object):
                 pseudo_sensors.append(cls.get_blueprint_name())
         return pseudo_sensors
 
-    def _create_object(self, uid, type_id, name, parent, spawn_pose, carla_actor=None):
+    def _create_object(self, uid, type_id, name, parent, spawn_pose, carla_actor=None, allow_transform=False):
 
         if type_id == TFSensor.get_blueprint_name():
             actor = TFSensor(uid=uid, name=name, parent=parent, node=self.node)
@@ -248,22 +249,22 @@ class ActorFactory(object):
             if carla_actor.type_id.startswith("sensor.camera"):
                 if carla_actor.type_id.startswith("sensor.camera.rgb"):
                     actor = RgbCamera(uid, name, parent, spawn_pose, self.node,
-                                      carla_actor, self.sync_mode)
+                                      carla_actor, self.sync_mode, allow_transform=allow_transform)
                 elif carla_actor.type_id.startswith("sensor.camera.depth"):
                     actor = DepthCamera(uid, name, parent, spawn_pose,
-                                        self.node, carla_actor, self.sync_mode)
+                                        self.node, carla_actor, self.sync_mode, allow_transform=allow_transform)
                 elif carla_actor.type_id.startswith(
                         "sensor.camera.semantic_segmentation"):
                     actor = SemanticSegmentationCamera(uid, name, parent,
                                                        spawn_pose, self.node,
                                                        carla_actor,
-                                                       self.sync_mode)
+                                                       self.sync_mode, allow_transform=allow_transform)
                 elif carla_actor.type_id.startswith("sensor.camera.dvs"):
                     actor = DVSCamera(uid, name, parent, spawn_pose, self.node,
-                                      carla_actor, self.sync_mode)
+                                      carla_actor, self.sync_mode, allow_transform=allow_transform)
                 else:
                     actor = Camera(uid, name, parent, spawn_pose, self.node,
-                                   carla_actor, self.sync_mode)
+                                   carla_actor, self.sync_mode, allow_transform=allow_transform)
             elif carla_actor.type_id.startswith("sensor.lidar"):
                 if carla_actor.type_id.endswith("sensor.lidar.ray_cast"):
                     actor = Lidar(uid, name, parent, spawn_pose, self.node,

--- a/carla_ros_bridge/src/carla_ros_bridge/bridge.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/bridge.py
@@ -153,7 +153,11 @@ class CarlaRosBridge(object):
         else:
             blueprint = self.carla_world.get_blueprint_library().find(req.type)
         blueprint.set_attribute('role_name', req.id)
+        allow_transform = False
         for attribute in req.attributes:
+            if attribute.key == "allow_transform":
+                allow_transform = attribute.value
+                continue
             blueprint.set_attribute(attribute.key, attribute.value)
         if req.random_pose is False:
             transform = trans.ros_pose_to_carla_transform(req.transform)
@@ -171,7 +175,7 @@ class CarlaRosBridge(object):
 
         carla_actor = self.carla_world.spawn_actor(blueprint, transform, attach_to)
         actor = self.actor_factory.create(
-            req.type, req.id, req.attach_to, req.transform, carla_actor)
+            req.type, req.id, req.attach_to, req.transform, carla_actor, allow_transform=allow_transform)
         return actor.uid
 
     def _spawn_pseudo_actor(self, req):

--- a/carla_spawn_objects/config/objects.json
+++ b/carla_spawn_objects/config/objects.json
@@ -42,7 +42,8 @@
                     "image_size_x": 800,
                     "image_size_y": 600,
                     "fov": 90.0,
-                    "sensor_tick": 0.05
+                    "sensor_tick": 0.05,
+                    "allow_transform": true
                 },
                 {
                     "type": "sensor.lidar.ray_cast",


### PR DESCRIPTION
Answer to issue https://github.com/carla-simulator/ros-bridge/issues/436
- uses new attribute _allow_transform_ from object.json
- if _allow_transform_ is set to true (only for camera sensors) the camera object subscribes to a new topic /carla/\<parent\>/\<sensor_name\>/update_pose
- Tested using rviz by remapping the topic /carla/ego_vehicle/spectator_pose, and by using the carla_rviz_plugin to move the view around. It works for all type of cameras, including when they are not attached to any vehicle.
- Not sure if that's the goal, but this should be able to replace the current spectator_camera node.

@fpasch is that what you had in mind?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/443)
<!-- Reviewable:end -->
