### PR TITLE
Fix spawn bug

### DIFF
--- a/carla_ros_bridge/src/carla_ros_bridge/actor_factory.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/actor_factory.py
@@ -78,8 +78,9 @@ class ActorFactory(object):
         while not self.node.shutdown.is_set():
             time.sleep(ActorFactory.TIME_BETWEEN_UPDATES)
 
-            self.world.wait_for_tick()
+            # self.world.wait_for_tick()
             with self.spawn_lock:
+                self.world.wait_for_tick()
                 self.update()
 
     def update(self):

--- a/carla_ros_bridge/src/carla_ros_bridge/actor_factory.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/actor_factory.py
@@ -77,8 +77,6 @@ class ActorFactory(object):
         """
         while not self.node.shutdown.is_set():
             time.sleep(ActorFactory.TIME_BETWEEN_UPDATES)
-
-            # self.world.wait_for_tick()
             with self.spawn_lock:
                 self.world.wait_for_tick()
                 self.update()

--- a/carla_ros_bridge/src/carla_ros_bridge/actor_factory.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/actor_factory.py
@@ -100,7 +100,7 @@ class ActorFactory(object):
 
     def clear(self):
         ids = self.actors.keys()
-        for id_ in ids:
+        for id_ in list(ids):
             self.destroy(id_)
 
     def _create_carla_actor(self, carla_actor):


### PR DESCRIPTION
- first two commits to fix the update thread that wasn't waiting for carla actor list to be updated before spawning missing actors
- third commit to fix error when destroying actors, can't iterate through dictionary and delete entries. To reproduce just launch the basic carla_ros_bridge launchfile, wait until all default actors are created, and quit with ctrl-C.
- A similar problem that I did not fix because it was hiding another one that I couldn't fix: when destroying an actor with attached sensor, (there: https://github.com/carla-simulator/ros-bridge/blob/master/carla_ros_bridge/src/carla_ros_bridge/actor_factory.py#L151), an error similar to the previous one is raised. But when it's fixed, the actors are destroyed, but keep being re-created in https://github.com/carla-simulator/ros-bridge/blob/master/carla_ros_bridge/src/carla_ros_bridge/actor_factory.py#L94. I couldn't fix this, might try again tomorrow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/444)
<!-- Reviewable:end -->
