### PR TITLE
Fix agent trafficlights

### DIFF
--- a/carla_ad_agent/launch/carla_ad_agent.launch.py
+++ b/carla_ad_agent/launch/carla_ad_agent.launch.py
@@ -5,11 +5,41 @@ import launch
 import launch_ros.actions
 
 
+def launch_setup(context, *args, **kwargs):
+    # workaround to use launch argument 'role_name' as a part of the string used for the node's name
+    node_name = 'carla_ad_agent_' + \
+        launch.substitutions.LaunchConfiguration('role_name').perform(context)
+
+    carla_ad_demo = launch_ros.actions.Node(
+        package='carla_ad_agent',
+        executable='carla_ad_agent',
+        name=node_name,
+        output='screen',
+        parameters=[
+            {
+                'target_speed': launch.substitutions.LaunchConfiguration('target_speed')
+            },
+            {
+                'role_name': launch.substitutions.LaunchConfiguration('role_name')
+            },
+            {
+                'avoid_risk': launch.substitutions.LaunchConfiguration('avoid_risk')
+            }
+        ]
+    )
+
+    return [carla_ad_demo]
+
+
 def generate_launch_description():
     ld = launch.LaunchDescription([
         launch.actions.DeclareLaunchArgument(
             name='role_name',
             default_value='ego_vehicle'
+        ),
+        launch.actions.SetLaunchConfiguration(
+            name='test',
+            value='jb'
         ),
         launch.actions.DeclareLaunchArgument(
             name='target_speed',
@@ -19,23 +49,7 @@ def generate_launch_description():
             name='avoid_risk',
             default_value='True'
         ),
-        launch_ros.actions.Node(
-            package='carla_ad_agent',
-            executable='carla_ad_agent',
-            name=launch.substitutions.LaunchConfiguration('role_name'),
-            output='screen',
-            parameters=[
-                {
-                    'target_speed': launch.substitutions.LaunchConfiguration('target_speed')
-                },
-                {
-                    'role_name': launch.substitutions.LaunchConfiguration('role_name')
-                },
-                {
-                    'avoid_risk': launch.substitutions.LaunchConfiguration('avoid_risk')
-                }
-            ]
-        )
+        launch.actions.OpaqueFunction(function=launch_setup)
     ])
     return ld
 

--- a/carla_ad_agent/src/carla_ad_agent/agent.py
+++ b/carla_ad_agent/src/carla_ad_agent/agent.py
@@ -62,7 +62,8 @@ class Agent(object):
 
             self._traffic_lights = []
             self._traffic_light_status_subscriber = node.create_subscriber(CarlaTrafficLightStatusList,
-                                                                           "/carla/traffic_lights", self.traffic_lights_updated)
+                                                                           "/carla/traffic_lights/status", self.traffic_lights_updated,
+                                                                           qos_profile=QoSProfile(depth=10, durability=latch_on))
 
             node.create_subscriber(CarlaWorldInfo,
                                    "/carla/world_info", self.world_info_updated, qos_profile=QoSProfile(depth=1, durability=latch_on))

--- a/carla_ad_agent/src/carla_ad_agent/basic_agent.py
+++ b/carla_ad_agent/src/carla_ad_agent/basic_agent.py
@@ -66,7 +66,7 @@ class BasicAgent(Agent):
             self._vehicle_id_list = []
             self._lights_id_list = []
             self._actors_subscriber = self.node.create_subscriber(CarlaActorList, "/carla/actor_list",
-                                                                  self.actors_updated, qos_profile=QoSProfile(depth=1, durability=latch_on), callback_group=cb_group)
+                                                                  self.actors_updated, callback_group=cb_group)
             self._objects = []
 
             self._objects_subscriber = self.node.create_subscriber(ObjectArray,
@@ -140,7 +140,6 @@ class BasicAgent(Agent):
             vehicle_state, vehicle = self._is_vehicle_hazard(  # pylint: disable=unused-variable
                 self._vehicle_id_list, self._objects)
             if vehicle_state:
-                #rospy.loginfo('=== Vehicle blocking ahead [{}])'.format(vehicle))
                 self._state = AgentState.BLOCKED_BY_VEHICLE
                 hazard_detected = True
 
@@ -148,8 +147,6 @@ class BasicAgent(Agent):
             light_state, traffic_light = self._is_light_red(  # pylint: disable=unused-variable
                 self._lights_id_list)
             if light_state:
-                #rospy.loginfo('=== Red Light ahead [{}])'.format(traffic_light))
-
                 self._state = AgentState.BLOCKED_RED_LIGHT
                 hazard_detected = True
 

--- a/carla_ad_demo/launch/carla_ad_demo_with_scenario.launch.py
+++ b/carla_ad_demo/launch/carla_ad_demo_with_scenario.launch.py
@@ -93,7 +93,7 @@ def generate_launch_description():
             ),
             launch_arguments={
                 'object_definition_file': get_package_share_directory('carla_spawn_objects') + '/config/objects.json',
-                'role_name_' + str(launch.substitutions.LaunchConfiguration('role_name')): launch.substitutions.LaunchConfiguration('role_name')
+                'role_name': launch.substitutions.LaunchConfiguration('role_name')
             }.items()
         ),
         launch.actions.IncludeLaunchDescription(

--- a/carla_manual_control/launch/carla_manual_control.launch.py
+++ b/carla_manual_control/launch/carla_manual_control.launch.py
@@ -5,24 +5,34 @@ import launch
 import launch_ros.actions
 
 
+def launch_setup(context, *args, **kwargs):
+    # workaround to use launch argument 'role_name' as a part of the string used for the node's name
+    node_name = 'carla_manual_control_' + \
+        launch.substitutions.LaunchConfiguration('role_name').perform(context)
+
+    carla_manual_control = launch_ros.actions.Node(
+        package='carla_manual_control',
+        executable='carla_manual_control',
+        name=node_name,
+        output='screen',
+        emulate_tty=True,
+        parameters=[
+            {
+                'role_name': launch.substitutions.LaunchConfiguration('role_name')
+            }
+        ]
+    )
+
+    return [carla_manual_control]
+
+
 def generate_launch_description():
     ld = launch.LaunchDescription([
         launch.actions.DeclareLaunchArgument(
             name='role_name',
             default_value='ego_vehicle'
         ),
-        launch_ros.actions.Node(
-            package='carla_manual_control',
-            executable='carla_manual_control',
-            name=launch.substitutions.LaunchConfiguration('role_name'),
-            output='screen',
-            emulate_tty=True,
-            parameters=[
-                {
-                    'role_name': launch.substitutions.LaunchConfiguration('role_name')
-                }
-            ]
-        )
+        launch.actions.OpaqueFunction(function=launch_setup)
     ])
     return ld
 

--- a/carla_manual_control/src/carla_manual_control/carla_manual_control.py
+++ b/carla_manual_control/src/carla_manual_control/carla_manual_control.py
@@ -367,7 +367,7 @@ class HUD(object):
         self.vehicle_info = CarlaEgoVehicleInfo()
         self.vehicle_info_subscriber = node.create_subscriber(
             CarlaEgoVehicleInfo, "/carla/{}/vehicle_info".format(self.role_name),
-            self.vehicle_info_updated, callback_group=self.callback_group)
+            self.vehicle_info_updated, callback_group=self.callback_group, qos_profile=QoSProfile(depth=10, durability=latch_on))
 
         self.latitude = 0
         self.longitude = 0
@@ -554,7 +554,7 @@ class HUD(object):
                     else:
                         rect_border = pygame.Rect((bar_h_offset, v_offset + 8), (bar_width, 6))
                         pygame.draw.rect(display, (255, 255, 255), rect_border, 1)
-                        if item[2] < 0.0:
+                        if item[2] <= 0.0:
                             f = (item[1] - item[2]) / (item[3] - item[2])
                             rect = pygame.Rect((bar_h_offset + int(f * (bar_width - 6)), v_offset + 8),
                                                (6, 6))

--- a/carla_spawn_objects/src/carla_spawn_objects/carla_spawn_objects.py
+++ b/carla_spawn_objects/src/carla_spawn_objects/carla_spawn_objects.py
@@ -159,7 +159,7 @@ class CarlaSpawnObjects(CompatibleNode):
                 spawn_point = None
 
                 # check if there's a spawn_point corresponding to this vehicle
-                spawn_point_param = self.get_param("~spawn_point_" + vehicle["id"], None)
+                spawn_point_param = self.get_param("spawn_point_" + vehicle["id"], None)
                 spawn_param_used = False
                 if (spawn_point_param is not None):
                     # try to use spawn_point from parameters


### PR DESCRIPTION
- fixed bug where manual_control and carla_ad_agent nodes were both renamed 'ego_vehicle' by their respective launchfile. I had to use an `launch.actions.OpaqueFunction` in the launchfiles in order to use the role_name parameter as a string directly in the `launch.LaunchDescription`, their might be a more elegant way to do that but I didn't find it!
- several bugs with parameter `spawn_point_<role_name>`, it was not taking into account.
- fixed topic names and QoSSettings preventing the carla_ad_agent to see the red trafficlights
- also fixed throttle and brake status bar that weren't being updated in pygames

tested in ros1/ros2 and sync/async

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/462)
<!-- Reviewable:end -->
