### PR TITLE
Update carla_ad_demo.launch.py

### DIFF
--- a/carla_ad_demo/launch/carla_ad_demo.launch.py
+++ b/carla_ad_demo/launch/carla_ad_demo.launch.py
@@ -17,7 +17,7 @@ def launch_carla_spawn_object(context, *args, **kwargs):
                 'carla_spawn_objects'), 'carla_example_ego_vehicle.launch.py')
         ),
         launch_arguments={
-            'object_definition_file': get_package_share_directory('carla_spawn_objects') + '/config/sensors.json',
+            'objects_definition_file': get_package_share_directory('carla_spawn_objects') + '/config/objects.json',
             spawn_point_param_name: launch.substitutions.LaunchConfiguration('spawn_point')
         }.items()
     )


### PR DESCRIPTION
ad demo launch file uses old name of sensor setup file, and wrong param name

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/474)
<!-- Reviewable:end -->
