### PR TITLE
Fixed rosdep installation errors for missing ros2 packages

### DIFF
--- a/carla_ackermann_control/package.xml
+++ b/carla_ackermann_control/package.xml
@@ -15,7 +15,6 @@
 
   <!-- ROS 2 DEPENDENCIES-->
   <depend condition="$ROS_VERSION == 2">rclpy</depend>
-  <buildtool_depend condition="$ROS_VERSION == 2">ament_python</buildtool_depend>
   <exec_depend condition="$ROS_VERSION == 2">tf2_ros</exec_depend>
 
   <!-- ROS 1 DEPENDENCIES-->

--- a/carla_ad_agent/package.xml
+++ b/carla_ad_agent/package.xml
@@ -20,7 +20,6 @@
 
   <!-- ROS 2 DEPENDENCIES-->
   <depend condition="$ROS_VERSION == 2">rclpy</depend>
-  <buildtool_depend condition="$ROS_VERSION == 2">ament_python</buildtool_depend>
 
   <export>
     <build_type condition="$ROS_VERSION == 1">catkin</build_type>

--- a/carla_ad_demo/package.xml
+++ b/carla_ad_demo/package.xml
@@ -18,7 +18,6 @@
   
 
   <!-- ROS 2 DEPENDENCIES-->
-  <buildtool_depend condition="$ROS_VERSION == 2">ament_python</buildtool_depend>
   <exec_depend condition="$ROS_VERSION == 2">rviz2</exec_depend>
 
   <!-- ROS 1 DEPENDENCIES-->

--- a/carla_common/package.xml
+++ b/carla_common/package.xml
@@ -8,8 +8,6 @@
 
   <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
 
-  <buildtool_depend condition="$ROS_VERSION == 2">ament_python</buildtool_depend>
-
   <export>
     <build_type condition="$ROS_VERSION == 1">catkin</build_type>
     <build_type condition="$ROS_VERSION == 2">ament_python</build_type>

--- a/carla_manual_control/package.xml
+++ b/carla_manual_control/package.xml
@@ -13,7 +13,6 @@
 
   <!-- ROS 2 DEPENDENCIES-->
   <depend condition="$ROS_VERSION == 2">rclpy</depend>
-  <buildtool_depend condition="$ROS_VERSION == 2">ament_python</buildtool_depend>
   <exec_depend condition="$ROS_VERSION == 2">tf2_ros</exec_depend>
 
   <!-- ROS 1 DEPENDENCIES-->

--- a/carla_ros_bridge/package.xml
+++ b/carla_ros_bridge/package.xml
@@ -25,7 +25,6 @@
 
   <!-- ROS 2 DEPENDENCIES-->
   <depend condition="$ROS_VERSION == 2">rclpy</depend>
-  <buildtool_depend condition="$ROS_VERSION == 2">ament_python</buildtool_depend>
   <exec_depend condition="$ROS_VERSION == 2">tf2_ros</exec_depend>
   <exec_depend condition="$ROS_VERSION == 2">rviz2</exec_depend>
 

--- a/carla_ros_scenario_runner/package.xml
+++ b/carla_ros_scenario_runner/package.xml
@@ -21,7 +21,6 @@
 
   <!-- ROS 2 DEPENDENCIES-->
   <depend condition="$ROS_VERSION == 2">rclpy</depend>
-  <buildtool_depend condition="$ROS_VERSION == 2">ament_python</buildtool_depend>
 
   <export>
     <build_type condition="$ROS_VERSION == 1">catkin</build_type>

--- a/carla_ros_scenario_runner_types/package.xml
+++ b/carla_ros_scenario_runner_types/package.xml
@@ -16,7 +16,6 @@
 
   <depend condition="$ROS_VERSION == 2">builtin_interfaces</depend>
   
-  <exec_depend>message_runtime</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
 
   <exec_depend condition="$ROS_VERSION == 1">message_runtime</exec_depend>

--- a/carla_spawn_objects/package.xml
+++ b/carla_spawn_objects/package.xml
@@ -12,7 +12,6 @@
 
   <!-- ROS 2 DEPENDENCIES-->
   <depend condition="$ROS_VERSION == 2">rclpy</depend>
-  <buildtool_depend condition="$ROS_VERSION == 2">ament_python</buildtool_depend>
 
   <!-- ROS 1 DEPENDENCIES-->
   <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>

--- a/carla_walker_agent/package.xml
+++ b/carla_walker_agent/package.xml
@@ -19,7 +19,6 @@
   
   <!-- ROS 2 DEPENDENCIES-->
   <depend condition="$ROS_VERSION == 2">rclpy</depend>
-  <buildtool_depend condition="$ROS_VERSION == 2">ament_python</buildtool_depend>
 
   <export>
     <build_type condition="$ROS_VERSION == 1">catkin</build_type>

--- a/carla_waypoint_publisher/package.xml
+++ b/carla_waypoint_publisher/package.xml
@@ -18,7 +18,6 @@
 
   <!-- ROS 2 DEPENDENCIES-->
   <depend condition="$ROS_VERSION == 2">rclpy</depend>
-  <buildtool_depend condition="$ROS_VERSION == 2">ament_python</buildtool_depend>
   
 
 


### PR DESCRIPTION
Running `rosdep install -y --from-paths src --ignore-src` command on ros2 branch gives errors:
```
ERROR: the following packages/stacks could not have their rosdep keys resolved to system dependencies:
carla_waypoint_publisher: Cannot locate rosdep definition for [ament_python]
carla_ros_scenario_runner_types: Cannot locate rosdep definition for [message_runtime]
carla_ad_agent: Cannot locate rosdep definition for [ament_python]
carla_ad_demo: Cannot locate rosdep definition for [ament_python]
carla_ackermann_control: Cannot locate rosdep definition for [ament_python]
carla_common: Cannot locate rosdep definition for [ament_python]
carla_spawn_objects: Cannot locate rosdep definition for [ament_python]
carla_manual_control: Cannot locate rosdep definition for [ament_python]
carla_ros_scenario_runner: Cannot locate rosdep definition for [ament_python]
carla_ros_bridge: Cannot locate rosdep definition for [ament_python]
carla_walker_agent: Cannot locate rosdep definition for [ament_python]
```

ament_python dependency is not correct as described here: https://github.com/ros2/ros2cli/pull/428

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/475)
<!-- Reviewable:end -->
