### PR TITLE
application runner can take simple string as argument list

### DIFF
--- a/carla_ros_scenario_runner/src/carla_ros_scenario_runner/application_runner.py
+++ b/carla_ros_scenario_runner/src/carla_ros_scenario_runner/application_runner.py
@@ -100,10 +100,15 @@ class ApplicationRunner(object):
         """
         if not argument_list:
             raise KeyError("No arguments given!")
-        executable = argument_list[0]
-        log_fct("Executing: {}".format(" ".join(argument_list)))
-        process = pexpect.spawn(" ".join(argument_list), env=env, cwd=cwd, encoding='utf-8')
+        if not isinstance(argument_list, str):
+            executable = " ".join(argument_list)
+        else:
+            executable = argument_list
+            
+        log_fct("Executing: " + executable)
+        process = pexpect.spawn(executable, env=env, cwd=cwd, encoding='utf-8')
         #process.logfile_read = sys.stdout
+
         return process
 
     def run(self, process, shutdown_requested_event, ready_string, status_updated_fct, log_fct):  # pylint: disable=no-self-use,too-many-arguments


### PR DESCRIPTION
Option to give a simple string with the complete cmd line to be executed to application runner. Simpler than a list of every word of the command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/481)
<!-- Reviewable:end -->
