### PR TITLE
ego_vehicle does not subscribe to cmd topics when bridge in passive m…

### DIFF
--- a/carla_ros_bridge/src/carla_ros_bridge/ego_vehicle.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/ego_vehicle.py
@@ -75,25 +75,27 @@ class EgoVehicle(Vehicle):
                                                          "/vehicle_info",
                                                          qos_profile=QoSProfile(depth=10, durability=latch_on))
 
-        self.control_subscriber = node.create_subscriber(
-            CarlaEgoVehicleControl,
-            self.get_topic_prefix() + "/vehicle_control_cmd",
-            lambda data: self.control_command_updated(data, manual_override=False))
+        # only subscribe to control topics if passive mode is not activated
+        if not node.parameters["passive"]:
+            self.control_subscriber = node.create_subscriber(
+                CarlaEgoVehicleControl,
+                self.get_topic_prefix() + "/vehicle_control_cmd",
+                lambda data: self.control_command_updated(data, manual_override=False))
 
-        self.manual_control_subscriber = node.create_subscriber(
-            CarlaEgoVehicleControl,
-            self.get_topic_prefix() + "/vehicle_control_cmd_manual",
-            lambda data: self.control_command_updated(data, manual_override=True))
+            self.manual_control_subscriber = node.create_subscriber(
+                CarlaEgoVehicleControl,
+                self.get_topic_prefix() + "/vehicle_control_cmd_manual",
+                lambda data: self.control_command_updated(data, manual_override=True))
 
-        self.control_override_subscriber = node.create_subscriber(
-            Bool,
-            self.get_topic_prefix() + "/vehicle_control_manual_override",
-            self.control_command_override, QoSProfile(depth=1, durability=True))
+            self.control_override_subscriber = node.create_subscriber(
+                Bool,
+                self.get_topic_prefix() + "/vehicle_control_manual_override",
+                self.control_command_override, QoSProfile(depth=1, durability=True))
 
-        self.enable_autopilot_subscriber = node.create_subscriber(
-            Bool,
-            self.get_topic_prefix() + "/enable_autopilot",
-            self.enable_autopilot_updated)
+            self.enable_autopilot_subscriber = node.create_subscriber(
+                Bool,
+                self.get_topic_prefix() + "/enable_autopilot",
+                self.enable_autopilot_updated)
 
     def get_marker_color(self):
         """


### PR DESCRIPTION
…ode, useful for leaderboard
In leaderboard, an ego_vehicle object instance is needed in the bridge, but the leaderboard is in charge of applying the ctrl-cmd. This a straight forward way to prevent the bridge instance to do it itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/482)
<!-- Reviewable:end -->
