### PR TITLE
Removed redundant CXX-Standard in CARLA-RViz-Plugin

### DIFF
--- a/rviz_carla_plugin/CMakeLists.txt
+++ b/rviz_carla_plugin/CMakeLists.txt
@@ -31,8 +31,6 @@ if(${ROS_VERSION} EQUAL 1)
 
   target_link_libraries(${PROJECT_NAME} ${QT_LIBRARIES} ${catkin_LIBRARIES})
 
-  target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_14)
-
   install(
     TARGETS ${PROJECT_NAME}
     ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/488)
<!-- Reviewable:end -->
