### PR TITLE
added manual_gear_shift and gear field to ego control message

### DIFF
--- a/carla_ros_bridge/src/carla_ros_bridge/ego_vehicle.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/ego_vehicle.py
@@ -225,6 +225,8 @@ class EgoVehicle(Vehicle):
             vehicle_control.steer = ros_vehicle_control.steer
             vehicle_control.throttle = ros_vehicle_control.throttle
             vehicle_control.reverse = ros_vehicle_control.reverse
+            vehicle_control.manual_gear_shift = ros_vehicle_control.manual_gear_shift
+            vehicle_control.gear = ros_vehicle_control.gear
             self.carla_actor.apply_control(vehicle_control)
             self._vehicle_control_applied_callback(self.get_id())
 


### PR DESCRIPTION
VehicleControl messages have "manual_gear_shift" and "gear" subfields but the control_command_updated method does not have these fields.