### PR TITLE
[ROS2] Debian packages and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,7 @@ jobs:
           fetch-depth: 1
           submodules: true
       - name: Setup
-        run: |
-          packaging/install_dependencies.sh
+        run: packaging/install_dependencies.sh
       - name: ROS2 Build, Test, Lint
         if: ${{ matrix.ros_version == 2 }}
         shell: bash
@@ -108,5 +107,7 @@ jobs:
         with:
           fetch-depth: 1
           submodules: true
+      - name: Setup
+        run: packaging/install_dependencies.sh
       - name: Build Debian Package
         run: make deb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,10 @@ jobs:
         #  submodules: true
       - name: Setup
         run: |
-          #sudo apt-get update && sudo apt-get install wget unzip -y
+          sudo apt-get update && sudo apt-get install wget unzip -y
           #TODO: replace ros2 with master
-          #rm -rf carla_msgs && wget https://github.com/carla-simulator/ros-carla-msgs/archive/ros2.zip
-          #unzip ros2.zip -d carla_msgs && rm ros2.zip
-          git submodule update --init
+          rm -rf carla_msgs && wget https://github.com/carla-simulator/ros-carla-msgs/archive/ros2.zip
+          unzip ros2.zip -d carla_msgs && rm ros2.zip
           packaging/install_dependencies.sh
       - name: ROS2 Build, Test, Lint
         if: matrix.ros-version == 'foxy'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
             ros_version: 1
 
           - docker_image: foxy
-            ros_distro: melodic
+            ros_distro: foxy
             ros_python_version: 3
             ros_version: 2
     container:
@@ -57,7 +57,7 @@ jobs:
           unzip ros2.zip -d carla_msgs && rm ros2.zip
           packaging/install_dependencies.sh
       - name: ROS2 Build, Test, Lint
-        if: matrix.ros-version == 'foxy'
+        if: ${{ matrix.ros_version == 2 }}
         shell: bash
         run: |
           source /opt/ros/$(rosversion -d)/setup.bash
@@ -65,7 +65,7 @@ jobs:
           # colcon test && colcon test-result
           source install/setup.bash
       - name: ROS1 Build, Test, Lint
-        if: matrix.ros-version != 'foxy'
+        if: ${{ matrix.ros_version == 1 }}
         shell: bash
         run: |
           mkdir -p $GITHUB_WORKSPACE/../catkin_ws/src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,65 +6,81 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-    - name: Check
-      run: make check_format
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Check
+        run: make check_format
 
   ros:
     runs-on: ubuntu-latest
-    container: ros:${{ matrix.ros-version }}
     strategy:
       matrix:
-        ros-version: [melodic-robot, noetic-robot, foxy]
+        include:
+          - docker_image: melodic-robot
+            ros_distro: melodic
+            ros_python_version: 2
+            ros_version: 1
+
+          - docker_image: noetic-robot
+            ros_distro: noetic
+            ros_python_version: 3
+            ros_version: 1
+
+          - docker_image: foxy
+            ros_distro: melodic
+            ros_python_version: 3
+            ros_version: 2
+    container:
+      image: ros:${{ matrix.docker_image }}
     env:
       SCENARIO_RUNNER_PATH: ""
       DEBIAN_FRONTEND: "noninteractive"
+      ROS_DISTRO: ${{ matrix.ros_distro }}
+      ROS_VERSION: ${{ matrix.ros_version }}
+      ROS_PYTHON_VERSION: ${{ matrix.ros_python_version }}
     steps:
-    - uses: actions/checkout@v2
-    # TODO cleaner solution but currently not working because git version is below 2.18
-    #   with:
-    #     submodules: true
-    - name: Setup
-      run: |
-        sudo apt-get update && sudo apt-get install wget unzip -y
-        #TODO: replace ros2 with master
-        rm -rf carla_msgs && wget https://github.com/carla-simulator/ros-carla-msgs/archive/ros2.zip
-        unzip ros2.zip -d carla_msgs && rm ros2.zip
-        source /opt/ros/$(rosversion -d)/setup.bash
-        packaging/install_dependencies.sh
-    - name: ROS2 Build, Test, Lint
-      if: matrix.ros-version == 'foxy'
-      shell: bash
-      run: |
-        #source /opt/ros/$(rosversion -d)/setup.bash
-        colcon build --continue-on-error
-        # colcon test && colcon test-result
-        source install/setup.bash
-    - name: ROS1 Build, Test, Lint
-      if: matrix.ros-version != 'foxy'
-      shell: bash
-      run: |
-        mkdir -p $GITHUB_WORKSPACE/../catkin_ws/src
-        cd $GITHUB_WORKSPACE/../catkin_ws/src
-        ln -s $GITHUB_WORKSPACE
-        cd ..
-        catkin init
-        #source /opt/ros/$(rosversion -d)/setup.bash
-        cd $GITHUB_WORKSPACE/../catkin_ws &&
-        catkin build --summarize --no-status --force-color
-        catkin run_tests --no-status --force-color && catkin_test_results
-        source devel/setup.bash
-        cd $GITHUB_WORKSPACE
-      #  make pylint
-      # TODO enable pylint
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Setup
+        run: |
+          #sudo apt-get update && sudo apt-get install wget unzip -y
+          #TODO: replace ros2 with master
+          #rm -rf carla_msgs && wget https://github.com/carla-simulator/ros-carla-msgs/archive/ros2.zip
+          #unzip ros2.zip -d carla_msgs && rm ros2.zip
+          packaging/install_dependencies.sh
+      - name: ROS2 Build, Test, Lint
+        if: matrix.ros-version == 'foxy'
+        shell: bash
+        run: |
+          source /opt/ros/$(rosversion -d)/setup.bash
+          colcon build --continue-on-error
+          # colcon test && colcon test-result
+          source install/setup.bash
+      - name: ROS1 Build, Test, Lint
+        if: matrix.ros-version != 'foxy'
+        shell: bash
+        run: |
+          mkdir -p $GITHUB_WORKSPACE/../catkin_ws/src
+          cd $GITHUB_WORKSPACE/../catkin_ws/src
+          ln -s $GITHUB_WORKSPACE
+          cd ..
+          catkin init
+          source /opt/ros/$(rosversion -d)/setup.bash
+          cd $GITHUB_WORKSPACE/../catkin_ws &&
+          catkin build --summarize --no-status --force-color
+          catkin run_tests --no-status --force-color && catkin_test_results
+          source devel/setup.bash
+          cd $GITHUB_WORKSPACE
+        #  make pylint
+        # TODO enable pylint
 
   debian:
     runs-on: ubuntu-latest
@@ -76,6 +92,6 @@ jobs:
       SCENARIO_RUNNER_PATH: ""
       DEBIAN_FRONTEND: "noninteractive"
     steps:
-    - uses: actions/checkout@v2
-    - name: Build Debian Package
-      run: packaging/build-deb.sh
+      - uses: actions/checkout@v2
+      - name: Build Debian Package
+        run: packaging/build-deb.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,16 +46,13 @@ jobs:
       ROS_VERSION: ${{ matrix.ros_version }}
       ROS_PYTHON_VERSION: ${{ matrix.ros_python_version }}
     steps:
-      - uses: actions/checkout@v2
-        # TODO cleaner solution but currently not working because git version is below 2.18
-        # with:
-        #   submodules: true
+      # We currently cannot use checkout@v2 because git version on ros images is below 2.18
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+          submodules: true
       - name: Setup
         run: |
-          sudo apt-get update && sudo apt-get install wget unzip -y
-          #TODO: replace ros2 with master
-          rm -rf carla_msgs && wget https://github.com/carla-simulator/ros-carla-msgs/archive/ros2.zip
-          unzip ros2.zip -d carla_msgs && rm ros2.zip
           packaging/install_dependencies.sh
       - name: ROS2 Build, Test, Lint
         if: ${{ matrix.ros_version == 2 }}
@@ -83,24 +80,28 @@ jobs:
         #  make pylint
         # TODO enable pylint
 
-  # debian:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       include:
-  #         - docker_image: melodic-robot
-  #           ros_distro: melodic
-  #           ros_python_version: 2
-  #           ros_version: 1
-  #   container:
-  #     image: ros:${{ matrix.docker_image }}
-  #   env:
-  #     SCENARIO_RUNNER_PATH: ""
-  #     DEBIAN_FRONTEND: "noninteractive"
-  #     ROS_DISTRO: ${{ matrix.ros_distro }}
-  #     ROS_VERSION: ${{ matrix.ros_version }}
-  #     ROS_PYTHON_VERSION: ${{ matrix.ros_python_version }}
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Build Debian Package
-  #       run: make deb
+  debian:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - docker_image: melodic-robot
+            ros_distro: melodic
+            ros_python_version: 2
+            ros_version: 1
+    container:
+      image: ros:${{ matrix.docker_image }}
+    env:
+      SCENARIO_RUNNER_PATH: ""
+      DEBIAN_FRONTEND: "noninteractive"
+      ROS_DISTRO: ${{ matrix.ros_distro }}
+      ROS_VERSION: ${{ matrix.ros_version }}
+      ROS_PYTHON_VERSION: ${{ matrix.ros_python_version }}
+    steps:
+      # We currently cannot use checkout@v2 because git version on ros images is below 2.18
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+          submodules: true
+      - name: Build Debian Package
+        run: make deb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
             ros_python_version: 2
             ros_version: 1
 
-            - docker_image: noetic-robot
+          - docker_image: noetic-robot
             ros_distro: noetic
             ros_python_version: 3
             ros_version: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,14 +84,22 @@ jobs:
 
   debian:
     runs-on: ubuntu-latest
-    container: ros:${{ matrix.ros-version }}
     strategy:
       matrix:
-        ros-version: [melodic-robot, noetic-robot, foxy]
+        include:
+          - docker_image: melodic-robot
+            ros_distro: melodic
+            ros_python_version: 2
+            ros_version: 1
+    container:
+      image: ros:${{ matrix.docker_image }}
     env:
       SCENARIO_RUNNER_PATH: ""
       DEBIAN_FRONTEND: "noninteractive"
+      ROS_DISTRO: ${{ matrix.ros_distro }}
+      ROS_VERSION: ${{ matrix.ros_version }}
+      ROS_PYTHON_VERSION: ${{ matrix.ros_python_version }}
     steps:
       - uses: actions/checkout@v2
       - name: Build Debian Package
-        run: packaging/build-deb.sh
+        run: make deb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,13 @@ jobs:
         #TODO: replace ros2 with master
         rm -rf carla_msgs && wget https://github.com/carla-simulator/ros-carla-msgs/archive/ros2.zip
         unzip ros2.zip -d carla_msgs && rm ros2.zip
+        source /opt/ros/$(rosversion -d)/setup.bash
         packaging/install_dependencies.sh
     - name: ROS2 Build, Test, Lint
       if: matrix.ros-version == 'foxy'
       shell: bash
       run: |
-        source /opt/ros/$(rosversion -d)/setup.bash
+        #source /opt/ros/$(rosversion -d)/setup.bash
         colcon build --continue-on-error
         # colcon test && colcon test-result
         source install/setup.bash
@@ -56,7 +57,7 @@ jobs:
         ln -s $GITHUB_WORKSPACE
         cd ..
         catkin init
-        source /opt/ros/$(rosversion -d)/setup.bash
+        #source /opt/ros/$(rosversion -d)/setup.bash
         cd $GITHUB_WORKSPACE/../catkin_ws &&
         catkin build --summarize --no-status --force-color
         catkin run_tests --no-status --force-color && catkin_test_results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,9 @@ jobs:
       ROS_PYTHON_VERSION: ${{ matrix.ros_python_version }}
     steps:
       - uses: actions/checkout@v2
-        #with:
-        #  submodules: true
+        # TODO cleaner solution but currently not working because git version is below 2.18
+        # with:
+        #   submodules: true
       - name: Setup
         run: |
           sudo apt-get update && sudo apt-get install wget unzip -y
@@ -82,24 +83,24 @@ jobs:
         #  make pylint
         # TODO enable pylint
 
-  debian:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - docker_image: melodic-robot
-            ros_distro: melodic
-            ros_python_version: 2
-            ros_version: 1
-    container:
-      image: ros:${{ matrix.docker_image }}
-    env:
-      SCENARIO_RUNNER_PATH: ""
-      DEBIAN_FRONTEND: "noninteractive"
-      ROS_DISTRO: ${{ matrix.ros_distro }}
-      ROS_VERSION: ${{ matrix.ros_version }}
-      ROS_PYTHON_VERSION: ${{ matrix.ros_python_version }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build Debian Package
-        run: make deb
+  # debian:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       include:
+  #         - docker_image: melodic-robot
+  #           ros_distro: melodic
+  #           ros_python_version: 2
+  #           ros_version: 1
+  #   container:
+  #     image: ros:${{ matrix.docker_image }}
+  #   env:
+  #     SCENARIO_RUNNER_PATH: ""
+  #     DEBIAN_FRONTEND: "noninteractive"
+  #     ROS_DISTRO: ${{ matrix.ros_distro }}
+  #     ROS_VERSION: ${{ matrix.ros_version }}
+  #     ROS_PYTHON_VERSION: ${{ matrix.ros_python_version }}
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Build Debian Package
+  #       run: make deb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,11 @@ jobs:
             ros_distro: melodic
             ros_python_version: 2
             ros_version: 1
+
+            - docker_image: noetic-robot
+            ros_distro: noetic
+            ros_python_version: 3
+            ros_version: 1
     container:
       image: ros:${{ matrix.docker_image }}
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,14 +47,15 @@ jobs:
       ROS_PYTHON_VERSION: ${{ matrix.ros_python_version }}
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: true
+        #with:
+        #  submodules: true
       - name: Setup
         run: |
           #sudo apt-get update && sudo apt-get install wget unzip -y
           #TODO: replace ros2 with master
           #rm -rf carla_msgs && wget https://github.com/carla-simulator/ros-carla-msgs/archive/ros2.zip
           #unzip ros2.zip -d carla_msgs && rm ros2.zip
+          git submodule update --init
           packaging/install_dependencies.sh
       - name: ROS2 Build, Test, Lint
         if: matrix.ros-version == 'foxy'

--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,6 @@ check_format:
 
 pylint:
 	$(PY_FILES) | xargs pylint --rcfile=.pylintrc
+
+deb:
+	./packaging/build-deb.sh

--- a/packaging/build-deb.sh
+++ b/packaging/build-deb.sh
@@ -5,11 +5,9 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_DIR=${SCRIPT_DIR}/build/$(rosversion -d)
 WORKSPACE_DIR=${BUILD_DIR}/catkin_ws
-ROS_VERSION=$(rosversion -d)
-if [ "$ROS_VERSION" = "noetic" -o "$ROS_VERSION" = "foxy" ]; then
+PYTHON_SUFFIX=""
+if [ "$ROS_PYTHON_VERSION" = "3" ]; then
     PYTHON_SUFFIX=3
-else
-    PYTHON_SUFFIX=""
 fi
 
 sudo apt update

--- a/packaging/build-deb.sh
+++ b/packaging/build-deb.sh
@@ -2,9 +2,14 @@
 
 set -e
 
+if [ "${ROS_VERSION}" != "1" ]; then
+    echo "Only ROS1 packages are supported"
+    exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-BUILD_DIR=${SCRIPT_DIR}/build/$(rosversion -d)
-WORKSPACE_DIR=${BUILD_DIR}/catkin_ws
+BUILD_DIR=${PWD}/build/$(rosversion -d)
+WORKSPACE_DIR=${BUILD_DIR}/ws
 PYTHON_SUFFIX=""
 if [ "$ROS_PYTHON_VERSION" = "3" ]; then
     PYTHON_SUFFIX=3
@@ -25,7 +30,7 @@ mkdir -p ${BUILD_DIR} ${WORKSPACE_DIR}
 rsync -r ${SCRIPT_DIR}/../* ${WORKSPACE_DIR}/src --exclude packaging
 # init ros workspace
 source /opt/ros/$(rosversion -d)/setup.bash
-cd ${WORKSPACE_DIR} && catkin init
+cd ${WORKSPACE_DIR} && catkin_init_workspace
 # add debian files
 cp -r ${SCRIPT_DIR}/debian ${WORKSPACE_DIR}
 sed -i "s/{ROS_DIST}/$(rosversion -d)/g" ${WORKSPACE_DIR}/debian/control

--- a/packaging/build-deb.sh
+++ b/packaging/build-deb.sh
@@ -15,7 +15,7 @@ if [ "$ROS_PYTHON_VERSION" = "3" ]; then
     PYTHON_SUFFIX=3
 fi
 
-${SCRIPT_DIR}/install_dependencies.sh
+sudo apt update
 sudo apt-get install --no-install-recommends -y \
     rsync \
     build-essential \

--- a/packaging/build-deb.sh
+++ b/packaging/build-deb.sh
@@ -15,10 +15,8 @@ if [ "$ROS_PYTHON_VERSION" = "3" ]; then
     PYTHON_SUFFIX=3
 fi
 
-sudo apt update
+${SCRIPT_DIR}/install_dependencies.sh
 sudo apt-get install --no-install-recommends -y \
-    python$PYTHON_SUFFIX-osrf-pycommon \
-    python$PYTHON_SUFFIX-catkin-tools \
     rsync \
     build-essential \
     dh-make

--- a/packaging/install_dependencies.sh
+++ b/packaging/install_dependencies.sh
@@ -1,9 +1,5 @@
 #!/usr/bin/env bash
 
-echo "$ROS_VERSION"
-echo "$ROS_DISTRO"
-echo "$ROS_PYTHON_VERSION"
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PYTHON_SUFFIX=""
 if [ "$ROS_PYTHON_VERSION" = "3" ]; then

--- a/packaging/install_dependencies.sh
+++ b/packaging/install_dependencies.sh
@@ -1,20 +1,18 @@
 #!/usr/bin/env bash
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ROS_VERSION=$(rosversion -d)
-if [ "$ROS_VERSION" = "noetic" -o "$ROS_VERSION" = "foxy" ]; then
+PYTHON_SUFFIX=""
+if [ "$ROS_PYTHON_VERSION" = "3" ]; then
     PYTHON_SUFFIX=3
-else
-    PYTHON_SUFFIX=""
 fi
 
-if [ "$ROS_VERSION" = "foxy" ]; then
-    ADDITIONAL_PACKAGES="ros-$ROS_VERSION-rviz2"
+if [ "$ROS_VERSION" = "2" ]; then
+    ADDITIONAL_PACKAGES="ros-$ROS_DISTRO-rviz2"
 else
-    ADDITIONAL_PACKAGES="ros-$ROS_VERSION-rviz
-                         ros-$ROS_VERSION-opencv-apps
-                         ros-$ROS_VERSION-rospy-message-converter
-                         ros-$ROS_VERSION-pcl-ros"
+    ADDITIONAL_PACKAGES="ros-$ROS_DISTRO-rviz
+                         ros-$ROS_DISTRO-opencv-apps
+                         ros-$ROS_DISTRO-rospy-message-converter
+                         ros-$ROS_DISTRO-pcl-ros"
 fi
 echo ADDITIONAL PACKAGES $ADDITIONAL_PACKAGES
 
@@ -27,14 +25,14 @@ sudo apt-get install --no-install-recommends -y \
     python$PYTHON_SUFFIX-catkin-pkg-modules \
     python$PYTHON_SUFFIX-rosdep \
     python$PYTHON_SUFFIX-wstool \
-    ros-$ROS_VERSION-ackermann-msgs \
-    ros-$ROS_VERSION-derived-object-msgs \
-    ros-$ROS_VERSION-cv-bridge \
-    ros-$ROS_VERSION-vision-opencv \
-    ros-$ROS_VERSION-rqt-image-view \
-    ros-$ROS_VERSION-rqt-gui-py \
+    ros-$ROS_DISTRO-ackermann-msgs \
+    ros-$ROS_DISTRO-derived-object-msgs \
+    ros-$ROS_DISTRO-cv-bridge \
+    ros-$ROS_DISTRO-vision-opencv \
+    ros-$ROS_DISTRO-rqt-image-view \
+    ros-$ROS_DISTRO-rqt-gui-py \
     qt5-default \
-    ros-$ROS_VERSION-pcl-conversions \
+    ros-$ROS_DISTRO-pcl-conversions \
     $ADDITIONAL_PACKAGES
 
 pip$PYTHON_SUFFIX install -r $SCRIPT_DIR/../requirements.txt

--- a/packaging/install_dependencies.sh
+++ b/packaging/install_dependencies.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+echo "$ROS_VERSION"
+echo "$ROS_DISTRO"
+echo "$ROS_PYTHON_VERSION"
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PYTHON_SUFFIX=""
 if [ "$ROS_PYTHON_VERSION" = "3" ]; then


### PR DESCRIPTION
Updated CI and debian packaging scripts to take into account ROS2 changes.

*Important*: Debian packaging for ROS2 has been disabled (it wasn't working before). The whole debian packaging pipeline needs to be redesign to build ROS2 debian packages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/499)
<!-- Reviewable:end -->
