### PR TITLE
[ROS2] Fixed bug passive mode ang ego vehicle role names argument

### DIFF
--- a/carla_ros_bridge/launch/carla_ros_bridge.launch
+++ b/carla_ros_bridge/launch/carla_ros_bridge.launch
@@ -33,6 +33,7 @@
     <param name="synchronous_mode_wait_for_vehicle_control_command" value="$(arg synchronous_mode_wait_for_vehicle_control_command)"/>
     <param name="fixed_delta_seconds" value="$(arg fixed_delta_seconds)"/>
     <param name="town" value="$(arg town)"/>
+    <param name="ego_vehicle_role_name" value="$(arg ego_vehicle_role_name)"/>
   </node>
     
 </launch>

--- a/carla_ros_bridge/launch/carla_ros_bridge.launch.py
+++ b/carla_ros_bridge/launch/carla_ros_bridge.launch.py
@@ -37,7 +37,7 @@ def generate_launch_description():
             default_value='Town01'
         ),
         launch.actions.DeclareLaunchArgument(
-            name='ego_vehicle_role_names',
+            name='ego_vehicle_role_name',
             default_value=["hero", "ego_vehicle", "hero0", "hero1", "hero2",
                            "hero3", "hero4", "hero5", "hero6", "hero7", "hero8", "hero9"]
         ),
@@ -77,7 +77,7 @@ def generate_launch_description():
                     'town': launch.substitutions.LaunchConfiguration('town')
                 },
                 {
-                    'ego_vehicle_role_name': launch.substitutions.LaunchConfiguration('ego_vehicle_role_names')
+                    'ego_vehicle_role_name': launch.substitutions.LaunchConfiguration('ego_vehicle_role_name')
                 }
             ]
         )

--- a/carla_ros_bridge/src/carla_ros_bridge/ego_vehicle.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/ego_vehicle.py
@@ -70,7 +70,6 @@ class EgoVehicle(Vehicle):
                                                          "/vehicle_info",
                                                          qos_profile=QoSProfile(depth=10, durability=latch_on))
 
-        # only subscribe to control topics if passive mode is not activated
         self.control_subscriber = node.create_subscriber(
             CarlaEgoVehicleControl,
             self.get_topic_prefix() + "/vehicle_control_cmd",

--- a/carla_ros_bridge/src/carla_ros_bridge/ego_vehicle.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/ego_vehicle.py
@@ -71,26 +71,25 @@ class EgoVehicle(Vehicle):
                                                          qos_profile=QoSProfile(depth=10, durability=latch_on))
 
         # only subscribe to control topics if passive mode is not activated
-        if not node.parameters["passive"]:
-            self.control_subscriber = node.create_subscriber(
-                CarlaEgoVehicleControl,
-                self.get_topic_prefix() + "/vehicle_control_cmd",
-                lambda data: self.control_command_updated(data, manual_override=False))
+        self.control_subscriber = node.create_subscriber(
+            CarlaEgoVehicleControl,
+            self.get_topic_prefix() + "/vehicle_control_cmd",
+            lambda data: self.control_command_updated(data, manual_override=False))
 
-            self.manual_control_subscriber = node.create_subscriber(
-                CarlaEgoVehicleControl,
-                self.get_topic_prefix() + "/vehicle_control_cmd_manual",
-                lambda data: self.control_command_updated(data, manual_override=True))
+        self.manual_control_subscriber = node.create_subscriber(
+            CarlaEgoVehicleControl,
+            self.get_topic_prefix() + "/vehicle_control_cmd_manual",
+            lambda data: self.control_command_updated(data, manual_override=True))
 
-            self.control_override_subscriber = node.create_subscriber(
-                Bool,
-                self.get_topic_prefix() + "/vehicle_control_manual_override",
-                self.control_command_override, QoSProfile(depth=1, durability=True))
+        self.control_override_subscriber = node.create_subscriber(
+            Bool,
+            self.get_topic_prefix() + "/vehicle_control_manual_override",
+            self.control_command_override, QoSProfile(depth=1, durability=True))
 
-            self.enable_autopilot_subscriber = node.create_subscriber(
-                Bool,
-                self.get_topic_prefix() + "/enable_autopilot",
-                self.enable_autopilot_updated)
+        self.enable_autopilot_subscriber = node.create_subscriber(
+            Bool,
+            self.get_topic_prefix() + "/enable_autopilot",
+            self.enable_autopilot_updated)
 
     def get_marker_color(self):
         """


### PR DESCRIPTION
This PR fixes a couple of bugs:

* Subscribing again to the ego vehicle topics in passive mode. For the leaderboard use case, we won't create and `EgoVehicle` object as we will be calling the `bridge` with an empty list of ego vehicle role names.
* Fixed `ego_vehicle_role_name` not being used in ROS1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/507)
<!-- Reviewable:end -->
