### PR TITLE
Use 'catkin_install_python()' to make catkin handle the Python version

### DIFF
--- a/carla_ad_agent/CMakeLists.txt
+++ b/carla_ad_agent/CMakeLists.txt
@@ -18,9 +18,9 @@ if(${ROS_VERSION} EQUAL 1)
 
   include_directories(${catkin_INCLUDE_DIRS})
 
-  install(PROGRAMS src/carla_ad_agent/carla_ad_agent.py
-                   src/carla_ad_agent/local_planner.py
-          DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+  catkin_install_python(PROGRAMS src/carla_ad_agent/carla_ad_agent.py
+                                 src/carla_ad_agent/local_planner.py
+                        DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
   install(DIRECTORY launch/
           DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch)
 endif()

--- a/carla_ros_bridge/CMakeLists.txt
+++ b/carla_ros_bridge/CMakeLists.txt
@@ -20,8 +20,8 @@ if(${ROS_VERSION} EQUAL 1)
 
   include_directories(${catkin_INCLUDE_DIRS})
 
-  install(PROGRAMS src/carla_ros_bridge/bridge.py
-          DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
+  catkin_install_python(PROGRAMS src/carla_ros_bridge/bridge.py
+                        DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
   install(FILES src/carla_ros_bridge/CARLA_VERSION
           DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})


### PR DESCRIPTION
When running the carla_ros_bridge on 20.04 with both python2 and python3 installed, `catkin_install_python()` has to be used in order to automatically determine the correct python version for ROS.

Otherwise, the shebang `#!/usr/bin/env python` (as used in https://github.com/carla-simulator/ros-bridge/blob/master/carla_ros_bridge/src/carla_ros_bridge/bridge.py and https://github.com/carla-simulator/ros-bridge/blob/master/carla_ad_agent/src/carla_ad_agent/carla_ad_agent.py) can lead to using python2. 

However, by default, CARLA's PythonAPI is not installed for python2 in 20.04, so the current `install()` statements can lead to unexpected errors. 