### PR TITLE
Fix bug when spawning a vehicle with rolename other than ego_vehicle

### DIFF
--- a/carla_spawn_objects/src/carla_spawn_objects/carla_spawn_objects.py
+++ b/carla_spawn_objects/src/carla_spawn_objects/carla_spawn_objects.py
@@ -46,8 +46,8 @@ class CarlaSpawnObjects(CompatibleNode):
     def __init__(self):
         super(CarlaSpawnObjects, self).__init__('carla_spawn_objects')
 
-        self.objects_definition_file = self.get_param('objects_definition_file')
-        self.spawn_sensors_only = self.get_param('spawn_sensors_only', None)
+        self.objects_definition_file = self.get_param('objects_definition_file', '')
+        self.spawn_sensors_only = self.get_param('spawn_sensors_only', False)
 
         self.players = []
         self.vehicles_sensors = []

--- a/ros_compatibility/src/ros_compatibility/node.py
+++ b/ros_compatibility/src/ros_compatibility/node.py
@@ -25,7 +25,7 @@ if ROS_VERSION == 1:
         def __init__(self, name, **kwargs):
            pass
 
-        def get_param(self, name, alternative_value=None, alternative_name=None):
+        def get_param(self, name, alternative_value=None):
             if name.startswith('/'):
                 raise RuntimeError("Only private parameters are supported.")
             return rospy.get_param("~" + name, alternative_value)
@@ -142,12 +142,10 @@ elif ROS_VERSION == 2:
                 parameter_overrides=[param],
                 **kwargs)
 
-        def get_param(self, name, alternative_value=None, alternative_name=None):
-            if alternative_name is None:
-                alternative_name = name
+        def get_param(self, name, alternative_value=None):
             return self.get_parameter_or(
                 name,
-                Parameter(alternative_name, value=alternative_value)).value
+                Parameter(name, value=alternative_value)).value
 
         def get_time(self):
             t = self.get_clock().now()


### PR DESCRIPTION
This PR fixes a bug when spawning a vehicle with `rolename` other than ego_vehicle.

The issue is only happening with ROS1 and not with ROS2.
* In ROS2, we have the `allow_undeclared_parameters parameter` enabled. This means that if we request a non-existent parameter, we receive `None` (no exception raised).
* In ROS1, if we request a non-existent parameter and the alternative_value is `None`, it raises an error.

The current implementation in the PR solves this and the behavior for both distributions is exactly the same (i.e., if we request a non-existent parameter without an alternative value, it returns `None`).

On the other hand, the `alternative_name` argument has been removed. This argument is currently not used and, moreover, the `get_param` method returns a value and not a `Parameter` objects. Therefore, it does not make sensor to maintain it.

Fixes #517

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/552)
<!-- Reviewable:end -->
