### PR TITLE
Accelerate point cloud conversion to ROS messsge

### DIFF
--- a/carla_ros_bridge/src/carla_ros_bridge/sensor.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/sensor.py
@@ -276,7 +276,7 @@ def _get_struct_fmt(is_bigendian, fields, field_names=None):
     return fmt
 
 
-def _check_if_fast_byte_coversion_avaliable(fields, packed_point_size, points):
+def _check_if_fast_byte_conversion_available(fields, packed_point_size, points):
     _POINTTYPE_TO_NUMPY = {
         PointField.INT8: np.int8,
         PointField.UINT8: np.uint8,
@@ -319,7 +319,7 @@ def create_cloud(header, fields, points):
     """
 
     cloud_struct = struct.Struct(_get_struct_fmt(False, fields))
-    if _check_if_fast_byte_coversion_avaliable(fields, cloud_struct.size, points):
+    if _check_if_fast_byte_conversion_available(fields, cloud_struct.size, points):
         point_bytes = points.tobytes()
     else:
         buff = ctypes.create_string_buffer(cloud_struct.size * len(points))

--- a/carla_ros_bridge/src/carla_ros_bridge/sensor.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/sensor.py
@@ -13,7 +13,6 @@ from __future__ import print_function
 
 import ctypes
 import os
-
 try:
     import queue
 except ImportError:
@@ -45,6 +44,7 @@ _DATATYPES[PointField.FLOAT64] = ('d', 8)
 
 
 class Sensor(Actor):
+    
     """
     Actor implementation details for sensors
     """
@@ -176,7 +176,7 @@ class Sensor(Actor):
         if self.synchronous_mode:
             if self.sensor_tick_time:
                 self.next_data_expected_time = carla_sensor_data.timestamp + \
-                                               float(self.sensor_tick_time)
+                    float(self.sensor_tick_time)
             self.queue.put(carla_sensor_data)
         else:
             self.publish_tf(trans.carla_transform_to_ros_pose(
@@ -208,8 +208,8 @@ class Sensor(Actor):
                 if carla_sensor_data.frame != frame:
                     self.node.logwarn("{}({}): Received event for frame {}"
                                       " (expected {}). Process it anyways.".format(
-                        self.__class__.__name__, self.get_id(),
-                        carla_sensor_data.frame, frame))
+                                          self.__class__.__name__, self.get_id(),
+                                          carla_sensor_data.frame, frame))
                 self.node.logdebug("{}({}): process {}".format(
                     self.__class__.__name__, self.get_id(), frame))
                 self.publish_tf(trans.carla_transform_to_ros_pose(
@@ -220,9 +220,9 @@ class Sensor(Actor):
 
     def _update_synchronous_sensor(self, frame, timestamp):
         while not self.next_data_expected_time or \
-                (not self.queue.empty() or
-                 self.next_data_expected_time and
-                 self.next_data_expected_time < timestamp):
+            (not self.queue.empty() or
+             self.next_data_expected_time and
+             self.next_data_expected_time < timestamp):
             while True:
                 try:
                     carla_sensor_data = self.queue.get(timeout=1.0)


### PR DESCRIPTION
I this merge request I have significantly accelerated point cloud conversion to ROS message. 
I have noticed that `create_cloud` function is called with NumPy array representing points, therefore the points are already stored in a byte array in the same format as the message format.
According to documentation, the `points` argument can be any list of iterables, therefore I have added the helper function `_check_if_fast_byte_coversion_avaliable`, which checks if the fast path can be used in this case.
Most likely the create_cloud is only called with np.ndarray for points, but I am not familiar with this codebase to ensure it.

**Benchmark results:**

ROS Hz results before changes:
```
# ros2 topic hz /carla/ego_vehicle/vehicle_status -w 20
average rate: 10.965
        min: 0.086s max: 0.098s std dev: 0.00271s window: 20
average rate: 10.866
        min: 0.087s max: 0.103s std dev: 0.00326s window: 20
```

Benchmark of carla-bridge with **py-spy**
```
# sudo ~/.local/bin/py-spy top --pid $(pgrep bridge) --native
Total Samples 400
GIL: 69.00%, Active: 116.00%, Threads: 10

  %Own   %Total  OwnTime  TotalTime  Function (filename:line)                                                                        
 20.00%  20.00%   0.770s    0.770s   sched_yield (libc-2.31.so)
 15.00%  15.00%   0.530s    0.530s   pthread_cond_timedwait@@GLIBC_2.3.2 (libpthread-2.31.so)
  5.00%  22.00%   0.260s    0.940s   create_cloud (carla_ros_bridge/sensor.py:328)
  5.00%   5.00%   0.150s    0.150s   do_futex_wait.constprop.0 (libpthread-2.31.so)
  3.00%   3.00%   0.070s    0.070s   0x7f2941ef2a8f (numpy/core/_multiarray_umath.cpython-38-x86_64-linux-gnu.so)
  1.00%   3.00%   0.070s    0.170s   can_execute (rclpy/executors.py:446)
```
ROS HZ after my modifications:
```
# ros2 topic hz /carla/ego_vehicle/vehicle_status -w 20
average rate: 16.112
        min: 0.056s max: 0.071s std dev: 0.00347s window: 20
average rate: 16.529
        min: 0.057s max: 0.067s std dev: 0.00265s window: 20
```

Benchamark with py-spy after modifications
```
# sudo ~/.local/bin/py-spy top --pid $(pgrep bridge) --native
Total Samples 400
GIL: 69.00%, Active: 116.00%, Threads: 10

  %Own   %Total  OwnTime  TotalTime  Function (filename:line)                                                                        
 34.00%  34.00%   13.78s    13.78s   sched_yield (libc-2.31.so)
 14.00%  14.00%    8.52s     8.54s   pthread_cond_timedwait@@GLIBC_2.3.2 (libpthread-2.31.so)
  2.00%   2.00%    1.68s     1.68s   do_futex_wait.constprop.0 (libpthread-2.31.so)
  0.00%   0.00%    1.07s     1.07s   0x7f26641086c3 (libc-2.31.so)
  2.00%   2.00%   0.890s    0.890s   syscall (libc-2.31.so)
  2.00%   2.00%   0.870s    0.900s   __add__ (rclpy/waitable.py:42)
  0.00%   0.00%   0.700s    0.790s   __add__ (rclpy/waitable.py:40)
```

