### PR TITLE
Explicitly specified boost::shared_ptr for pcl 1.11+ compatibility.

### DIFF
--- a/pcl_recorder/include/PclRecorder.h
+++ b/pcl_recorder/include/PclRecorder.h
@@ -18,7 +18,7 @@ public:
 
   PclRecorder();
 
-  void callback(const pcl::PCLPointCloud2::ConstPtr& cloud);
+  void callback(const boost::shared_ptr<const pcl::PCLPointCloud2>& cloud);
 
 private:
   ros::NodeHandle nh;

--- a/pcl_recorder/src/PclRecorder.cpp
+++ b/pcl_recorder/src/PclRecorder.cpp
@@ -26,7 +26,7 @@ PclRecorder::PclRecorder()
   sub = nh.subscribe("/carla/" + roleName + "/lidar", 1, &PclRecorder::callback, this);
 }
 
-void PclRecorder::callback(const pcl::PCLPointCloud2::ConstPtr& cloud)
+void PclRecorder::callback(const boost::shared_ptr<const pcl::PCLPointCloud2>& cloud)
 {
   if ((cloud->width * cloud->height) == 0) {
     return;


### PR DESCRIPTION
Since version 1.11 PCL uses std::shared_ptr instead of boost::shared_ptr - https://github.com/PointCloudLibrary/pcl/releases/tag/pcl-1.11.0 

However, ROS1 only allows to use boost::shared_ptr in subscribe function. This MR allows ros-bridge to be used with all PCL versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/569)
<!-- Reviewable:end -->
