### PR TITLE
Fixed Mathematical sign error causing markers to show up below ground in rviz.

### DIFF
--- a/carla_ros_bridge/src/carla_ros_bridge/vehicle.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/vehicle.py
@@ -81,7 +81,7 @@ class Vehicle(TrafficParticipant):
         # Moving pivot point from the bottom (CARLA) to the center (ROS) of the bounding box.
         extent = self.carla_actor.bounding_box.extent
         marker_transform = self.carla_actor.get_transform()
-        marker_transform.location -= marker_transform.get_up_vector() * extent.z
+        marker_transform.location += marker_transform.get_up_vector() * extent.z
         return trans.carla_transform_to_ros_pose(marker_transform)
 
     def get_classification(self):


### PR DESCRIPTION
Fixed Mathematical sign error causing markers to show up below ground in rviz.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/575)
<!-- Reviewable:end -->
