### PR TITLE
Fix highrate sync

### DIFF
--- a/carla_ros_bridge/src/carla_ros_bridge/bridge.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/bridge.py
@@ -12,6 +12,7 @@ Class that handle communication between CARLA and ROS
 """
 
 import os
+import time
 import pkg_resources
 try:
     import queue
@@ -250,6 +251,8 @@ class CarlaRosBridge(CompatibleNode):
         """
         execution loop for synchronous mode
         """
+        # sleep 2 seconds to allow actor spawning time before the next tick
+        time.sleep(2)
         while not self.shutdown.is_set() and roscomp.ok():
             self.process_run_state()
 

--- a/carla_ros_bridge/src/carla_ros_bridge/sensor.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/sensor.py
@@ -222,7 +222,7 @@ class Sensor(Actor):
         while not self.next_data_expected_time or \
             (not self.queue.empty() or
              self.next_data_expected_time and
-             self.next_data_expected_time < timestamp):
+             self.next_data_expected_time < timestamp + 1e-8):
             while True:
                 try:
                     carla_sensor_data = self.queue.get(timeout=1.0)


### PR DESCRIPTION
fix for issue described in #589
https://github.com/carla-simulator/ros-bridge/issues/589
skipping old frame at sync mode, RGB sensors arrive at different frames and ignored 