### PR TITLE
Remove empty launch args default_value

### DIFF
--- a/carla_ros_bridge/launch/carla_ros_bridge_with_example_ego_vehicle.launch.py
+++ b/carla_ros_bridge/launch/carla_ros_bridge_with_example_ego_vehicle.launch.py
@@ -28,7 +28,7 @@ def generate_launch_description():
         ),
         launch.actions.DeclareLaunchArgument(
             name='spawn_point',
-            default_value=''
+            default_value='None'
         ),
         launch.actions.DeclareLaunchArgument(
             name='town',

--- a/carla_ros_bridge/test/ros_bridge_client_ros2_test.py
+++ b/carla_ros_bridge/test/ros_bridge_client_ros2_test.py
@@ -77,7 +77,7 @@ def generate_test_description():
         ),
         launch.actions.DeclareLaunchArgument(
             name='spawn_point',
-            default_value=''
+            default_value='None'
         ),
         launch.actions.DeclareLaunchArgument(
             name='objects_definition_file',

--- a/carla_spawn_objects/launch/carla_example_ego_vehicle.launch.py
+++ b/carla_spawn_objects/launch/carla_example_ego_vehicle.launch.py
@@ -17,7 +17,7 @@ def generate_launch_description():
         ),
         launch.actions.DeclareLaunchArgument(
             name='spawn_point_ego_vehicle',
-            default_value=''
+            default_value='None'
         ),
         launch.actions.DeclareLaunchArgument(
             name='spawn_sensors_only',

--- a/carla_spawn_objects/launch/carla_spawn_objects.launch.py
+++ b/carla_spawn_objects/launch/carla_spawn_objects.launch.py
@@ -15,7 +15,7 @@ def generate_launch_description():
         ),
         launch.actions.DeclareLaunchArgument(
             name='spawn_point_ego_vehicle',
-            default_value=''
+            default_value='None'
         ),
         launch.actions.DeclareLaunchArgument(
             name='spawn_sensors_only',


### PR DESCRIPTION
This PR fixes a bug found in foxy and newer distros that crashes the ROS 2 launch system when an argument with `default_value=''` is not overwritten. For some reason the empty string is internally converted to `None`, which raises the following error 

```
File "/opt/ros/foxy/lib/python3.8/site-packages/launch_ros/utilities/evaluate_parameters.py", line 95, in evaluate_parameter_dict
    raise TypeError(
TypeError: Allowed value types are bytes, bool, int, float, str, Sequence[bool], Sequence[int], 
Sequence[float], Sequence[str]. Got <class 'NoneType'>. If the parameter is meant to be a string, 
try wrapping it in launch_ros.parameter_descriptions.ParameterValue(value, value_type=str)
```

Similar problems can be found https://github.com/introlab/rtabmap_ros/issues/725, https://github.com/LORD-MicroStrain/ntrip_client/pull/16 and https://github.com/microsoft/Azure_Kinect_ROS_Driver/issues/246

The easiest solution is to replace the empty string with a non-empty string. When an invalid spawn-point is passed, the node issues the following warning and then informs that a random spawn point was chosen

```
[WARN] [carla_spawn_objects]: Invalid spawnpoint 'None'
[INFO] [carla_spawn_objects]: Spawn point selected at random
```

If a spawn point is specified in the object description, the system issues the warnings

```
[WARN] [carla_spawn_objects]: Invalid spawnpoint 'None'
[WARN] [carla_spawn_objects]: ego_vehicle: Could not use spawn point from parameters, the spawn point from config file will be used.
```

After this messages, the launch system proceeds normally

This PR solves the problem described in #603, even without explicit goal of Carla 0.9.13 support. I believe that it is highly likely that people trying to run the newest Carla version are also running the newest version of ROS 2, thus facing the error described here. Personally, I was able to run ros bridge with Carla 0.9.13 smoothly after this fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/622)
<!-- Reviewable:end -->
