### PR TITLE
Fill CarlaEgoVehicleControl message header

### DIFF
--- a/carla_ad_agent/src/carla_ad_agent/vehicle_pid_controller.py
+++ b/carla_ad_agent/src/carla_ad_agent/vehicle_pid_controller.py
@@ -55,8 +55,14 @@ class VehiclePIDController(object):  # pylint: disable=too-few-public-methods
         :return: control signal (throttle and steering)
         """
         control = CarlaEgoVehicleControl()
-        throttle = self._lon_controller.run_step(target_speed, current_speed)
-        steering = self._lat_controller.run_step(current_pose, waypoint)
+        if current_speed:
+            throttle = self._lon_controller.run_step(target_speed, current_speed)
+        else:
+            throttle = 0.0
+        if current_pose:
+            steering = self._lat_controller.run_step(current_pose, waypoint)
+        else:
+            sterring = 0.0
         control.steer = -steering
         control.throttle = throttle
         control.brake = 0.0

--- a/carla_ros_bridge/launch/carla_ros_bridge_with_example_ego_vehicle.launch.py
+++ b/carla_ros_bridge/launch/carla_ros_bridge_with_example_ego_vehicle.launch.py
@@ -72,7 +72,7 @@ def generate_launch_description():
                 'timeout': launch.substitutions.LaunchConfiguration('timeout'),
                 'vehicle_filter': launch.substitutions.LaunchConfiguration('vehicle_filter'),
                 'role_name': launch.substitutions.LaunchConfiguration('role_name'),
-                'spawn_point': launch.substitutions.LaunchConfiguration('spawn_point')
+                'spawn_point': str(launch.substitutions.LaunchConfiguration('spawn_point'))
             }.items()
         ),
         launch.actions.IncludeLaunchDescription(

--- a/carla_spawn_objects/launch/carla_example_ego_vehicle.launch.py
+++ b/carla_spawn_objects/launch/carla_example_ego_vehicle.launch.py
@@ -34,7 +34,7 @@ def generate_launch_description():
             ),
             launch_arguments={
                 'objects_definition_file': launch.substitutions.LaunchConfiguration('objects_definition_file'),
-                'spawn_point_ego_vehicle': launch.substitutions.LaunchConfiguration('spawn_point_ego_vehicle'),
+                'spawn_point_ego_vehicle': str(launch.substitutions.LaunchConfiguration('spawn_point_ego_vehicle')),
                 'spawn_sensors_only': launch.substitutions.LaunchConfiguration('spawn_sensors_only')
             }.items()
         ),

--- a/carla_spawn_objects/launch/carla_spawn_objects.launch.py
+++ b/carla_spawn_objects/launch/carla_spawn_objects.launch.py
@@ -33,7 +33,7 @@ def generate_launch_description():
                     'objects_definition_file': launch.substitutions.LaunchConfiguration('objects_definition_file')
                 },
                 {
-                    'spawn_point_ego_vehicle': launch.substitutions.LaunchConfiguration('spawn_point_ego_vehicle')
+                    'spawn_point_ego_vehicle': str(launch.substitutions.LaunchConfiguration('spawn_point_ego_vehicle'))
                 },
                 {
                     'spawn_sensors_only': launch.substitutions.LaunchConfiguration('spawn_sensors_only')


### PR DESCRIPTION
Fill the message header of CarlaEgoVehicleControl messages with header
received from odometry

Some robustness increases:
- make vehicle_pid_controller robust against missing speed/pose input
- make ROS2 launch.py files robust against empty spawn points