### PR TITLE
Fixed scenario runner node shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Latest changed
 
+*   Fixed scenario runner node shutdown for foxy
+*   Fixed actor synchronization creation
 *   Fix of scenario runner status
 
 ## CARLA-ROS-Bridge 0.9.11

--- a/carla_ad_demo/CMakeLists.txt
+++ b/carla_ad_demo/CMakeLists.txt
@@ -26,7 +26,7 @@ elseif(${ROS_VERSION} EQUAL 2)
 
   find_package(ament_cmake REQUIRED)
 
-  install(DIRECTORY config/ DESTINATION share/${PROJECT_NAME})
+  install(DIRECTORY config/ DESTINATION share/${PROJECT_NAME}/config)
 
   install(DIRECTORY launch/ DESTINATION share/${PROJECT_NAME})
 

--- a/carla_ros_scenario_runner/src/carla_ros_scenario_runner/carla_ros_scenario_runner_node.py
+++ b/carla_ros_scenario_runner/src/carla_ros_scenario_runner/carla_ros_scenario_runner_node.py
@@ -176,16 +176,16 @@ def main(args=None):
     try:
         scenario_runner.run()
     except KeyboardInterrupt:
-        loginfo("User requested shut down.")
+        scenario_runner.loginfo("User requested shut down.")
     finally:
         if scenario_runner._scenario_runner.is_running():
             scenario_runner.loginfo("Scenario Runner still running. Shutting down.")
             scenario_runner._scenario_runner.shutdown()
         del scenario_runner
-        if ROS_VERSION == 2:
-            spin_thread.join()
 
         roscomp.shutdown()
+        if ROS_VERSION == 2:
+            spin_thread.join()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes the scenario runner node shutdown for ROS2 Foxy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/629)
<!-- Reviewable:end -->
