### PR TITLE
Fix CI rosversion cmd missing (#626)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - docker_image: melodic-robot
-            ros_distro: melodic
-            ros_python_version: 2
-            ros_version: 1
+          #- docker_image: melodic-robot
+          #  ros_distro: melodic
+          #  ros_python_version: 2
+          #  ros_version: 1
 
           - docker_image: noetic-robot
             ros_distro: noetic
@@ -52,7 +52,9 @@ jobs:
           fetch-depth: 1
           submodules: true
       - name: Setup
-        run: ./install_dependencies.sh
+        run: |
+          ./install_dependencies.sh
+          sudo apt-get install --no-install-recommends -y python3-rospkg
       - name: ROS2 Build, Test, Lint
         if: ${{ matrix.ros_version == 2 }}
         shell: bash
@@ -69,8 +71,8 @@ jobs:
           cd $GITHUB_WORKSPACE/../catkin_ws/src
           ln -s $GITHUB_WORKSPACE
           cd ..
-          catkin init
           source /opt/ros/$(rosversion -d)/setup.bash
+          catkin init
           cd $GITHUB_WORKSPACE/../catkin_ws &&
           catkin build --summarize --no-status --force-color
           catkin run_tests --no-status --force-color && catkin_test_results

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -11,6 +11,7 @@ if [ "$ROS_VERSION" = "2" ]; then
 else
     ADDITIONAL_PACKAGES="ros-$ROS_DISTRO-rviz
                          ros-$ROS_DISTRO-opencv-apps
+                         ros-$ROS_DISTRO-rospy
                          ros-$ROS_DISTRO-rospy-message-converter
                          ros-$ROS_DISTRO-pcl-ros"
 fi


### PR DESCRIPTION
* Fix CI rosversion cmd missing

* Add missing rospy dependency

* rospy dependency actually not missing

fixing workflow ordering

* Add rospy package again

* disabling melodic temporarily

Co-authored-by: Joel Moriana <joel.moriana@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/631)
<!-- Reviewable:end -->
