### PR TITLE
Add workaround for object classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Latest
 
+*   Added workaround for vehicle classification 
+
 ## CARLA-ROS-Bridge 0.9.12
 
 *   Fixed scenario runner node shutdown for foxy

--- a/carla_ros_bridge/src/carla_ros_bridge/vehicle.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/vehicle.py
@@ -51,6 +51,20 @@ class Vehicle(TrafficParticipant):
                 self.classification = Object.CLASSIFICATION_TRUCK
             elif carla_actor.attributes['object_type'] == 'other':
                 self.classification = Object.CLASSIFICATION_OTHER_VEHICLE
+            else:
+                # object_type seems to be empty all the time, so try to identify at least some of them
+                if 'number_of_wheels' in carla_actor.attributes and \
+                   carla_actor.attributes['number_of_wheels'] == '2':
+                    motorcycle_keys = [ "yamaha", "kawasaki", "harley-davidson", "vespa" ]
+                    bicycle_keys = [ "crossbike", "gazelle", "diamondback" ]
+                    if any(x in carla_actor.type_id for x in motorcycle_keys):
+                      self.classification = Object.CLASSIFICATION_MOTORCYCLE
+                    elif any(x in carla_actor.type_id for x in bicycle_keys):
+                      self.classification = Object.CLASSIFICATION_BIKE
+                else:
+                    truck_keys = [ "sprinter", "ambulance", "firetruck", "carlacola" ]
+                    if any(x in carla_actor.type_id for x in truck_keys):
+                      self.classification = Object.CLASSIFICATION_TRUCK
 
         super(Vehicle, self).__init__(uid=uid,
                                       name=name,


### PR DESCRIPTION
object_type attribute is empty, therefore guess the object class based on the blueprint name as a workaround.
Fixes #582

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/641)
<!-- Reviewable:end -->
