### PR TITLE
Fill CarlaEgoVehicleControl message header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Latest
 
+*   Fill CarlaEgoVehicleControl message header
+
 ## CARLA-ROS-Bridge 0.9.12
 
 *   Fixed scenario runner node shutdown for foxy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Latest
 
-*   Fill CarlaEgoVehicleControl message header
+*   carla_ad_agent: Fill CarlaEgoVehicleControl message header
 
 ## CARLA-ROS-Bridge 0.9.12
 

--- a/carla_ad_agent/src/carla_ad_agent/local_planner.py
+++ b/carla_ad_agent/src/carla_ad_agent/local_planner.py
@@ -141,6 +141,11 @@ class LocalPlanner(CompatibleNode):
                 self.emergency_stop()
                 return
 
+            if (self._current_pose is None) or (self._current_speed is None) or (self._current_header is None):
+                self.loginfo("Waiting for first odometry message...")
+                self.emergency_stop()
+                return
+
             # when target speed is 0, brake.
             if self._target_speed == 0.0:
                 self.emergency_stop()

--- a/carla_ad_agent/src/carla_ad_agent/vehicle_pid_controller.py
+++ b/carla_ad_agent/src/carla_ad_agent/vehicle_pid_controller.py
@@ -62,7 +62,7 @@ class VehiclePIDController(object):  # pylint: disable=too-few-public-methods
         if current_pose:
             steering = self._lat_controller.run_step(current_pose, waypoint)
         else:
-            sterring = 0.0
+            steering = 0.0
         control.steer = -steering
         control.throttle = throttle
         control.brake = 0.0

--- a/carla_ad_agent/src/carla_ad_agent/vehicle_pid_controller.py
+++ b/carla_ad_agent/src/carla_ad_agent/vehicle_pid_controller.py
@@ -55,14 +55,8 @@ class VehiclePIDController(object):  # pylint: disable=too-few-public-methods
         :return: control signal (throttle and steering)
         """
         control = CarlaEgoVehicleControl()
-        if current_speed:
-            throttle = self._lon_controller.run_step(target_speed, current_speed)
-        else:
-            throttle = 0.0
-        if current_pose:
-            steering = self._lat_controller.run_step(current_pose, waypoint)
-        else:
-            steering = 0.0
+        throttle = self._lon_controller.run_step(target_speed, current_speed)
+        steering = self._lat_controller.run_step(current_pose, waypoint)
         control.steer = -steering
         control.throttle = throttle
         control.brake = 0.0

--- a/carla_ad_agent/src/carla_ad_agent/vehicle_pid_controller.py
+++ b/carla_ad_agent/src/carla_ad_agent/vehicle_pid_controller.py
@@ -55,8 +55,14 @@ class VehiclePIDController(object):  # pylint: disable=too-few-public-methods
         :return: control signal (throttle and steering)
         """
         control = CarlaEgoVehicleControl()
-        throttle = self._lon_controller.run_step(target_speed, current_speed)
-        steering = self._lat_controller.run_step(current_pose, waypoint)
+        if current_speed:
+            throttle = self._lon_controller.run_step(target_speed, current_speed)
+        else:
+            throttle = 0.0
+        if current_pose:
+            steering = self._lat_controller.run_step(current_pose, waypoint)
+        else:
+            sterring = 0.0
         control.steer = -steering
         control.throttle = throttle
         control.brake = 0.0


### PR DESCRIPTION
Fill the message header of CarlaEgoVehicleControl messages with header received from odometry

Some robustness increases:
- make vehicle_pid_controller robust against missing speed/pose input

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/643)
<!-- Reviewable:end -->
