### PR TITLE
Add tf2_eigen dependency for PCL recorder.

### DIFF
--- a/pcl_recorder/CMakeLists.txt
+++ b/pcl_recorder/CMakeLists.txt
@@ -66,7 +66,7 @@ elseif(${ROS_VERSION} EQUAL 2)
   add_executable(${PROJECT_NAME}_node src/PclRecorderROS2.cpp src/mainROS2.cpp)
 
   ament_target_dependencies(${PROJECT_NAME}_node rclcpp sensor_msgs
-                            pcl_conversions tf2 tf2_ros)
+                            pcl_conversions tf2 tf2_ros tf2_eigen)
 
   target_link_libraries(${PROJECT_NAME}_node ${Boost_SYSTEM_LIBRARY}
                         ${PCL_LIBRARIES})

--- a/pcl_recorder/include/PclRecorderROS2.h
+++ b/pcl_recorder/include/PclRecorderROS2.h
@@ -10,7 +10,7 @@
 #include <pcl_conversions/pcl_conversions.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
-#include <tf2_eigen/tf2_eigen.h>
+#include "tf2_eigen/tf2_eigen.hpp"
 #include <rclcpp/time_source.hpp>
 
 class PclRecorderROS2 : public rclcpp::Node

--- a/pcl_recorder/package.xml
+++ b/pcl_recorder/package.xml
@@ -24,11 +24,14 @@
 
   <build_depend>pcl_conversions</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>tf2_eigen</build_depend>
   <build_export_depend>pcl_conversions</build_export_depend>
   <build_export_depend>sensor_msgs</build_export_depend>
+  <build_export_depend>tf2_eigen</build_export_depend>
   <exec_depend>pcl_conversions</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>carla_ros_bridge</exec_depend>
+  <exec_depend>tf2_eigen</exec_depend>
   
   <export>
     <build_type condition="$ROS_VERSION == 1">catkin</build_type>


### PR DESCRIPTION
To build carla_ros_bridge in ROS2, additionally the `tf2_eigen` library is required.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/645)
<!-- Reviewable:end -->
