### PR TITLE
Fix the missing "response" argument in get_blueprints() signature

### DIFF
--- a/carla_ros_bridge/src/carla_ros_bridge/bridge.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/bridge.py
@@ -185,7 +185,7 @@ class CarlaRosBridge(CompatibleNode):
                 self._registered_actors.remove(actor)
         return response
 
-    def get_blueprints(self, req):
+    def get_blueprints(self, req, response=None):
         response = roscomp.get_service_response(GetBlueprints)
         if req.filter:
             bp_filter = req.filter


### PR DESCRIPTION
The method `get_blueprints()` backing the `/carla/get_blueprints` service misses a `response` argument. The PR fixes it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/647)
<!-- Reviewable:end -->
