### PR TITLE
correct position of walkers.

### DIFF
--- a/carla_ros_bridge/src/carla_ros_bridge/walker.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/walker.py
@@ -10,6 +10,7 @@
 Classes to handle Carla pedestrians
 """
 
+import carla_common.transforms as trans
 from carla import WalkerControl
 
 from carla_ros_bridge.traffic_participant import TrafficParticipant
@@ -81,6 +82,19 @@ class Walker(TrafficParticipant):
         walker_control.speed = ros_walker_control.speed
         walker_control.jump = ros_walker_control.jump
         self.carla_actor.apply_control(walker_control)
+
+    def get_current_ros_pose(self):
+        """
+        Function to return the pose for walkers.
+
+        :return: the pose of the walker
+        :rtype: geometry_msgs.msg.Pose
+        """
+        # Moving position of walkers from the pivot point to the bottom of the bounding box.
+        extent = self.carla_actor.bounding_box.extent
+        pose_transform = self.carla_actor.get_transform()
+        pose_transform.location -= pose_transform.get_up_vector() * extent.z
+        return trans.carla_transform_to_ros_pose(pose_transform)
 
     def get_classification(self):
         """


### PR DESCRIPTION
I'm trying to generate training data with carla-simulator, and fetch image/pointcloud/objects information via carla-ros-bridge.
the problem is the message at `/carla/ego_vehicle/objects` or `/carla/objects` topic with `[derived_object_msgs](https://docs.ros.org/en/kinetic/api/derived_object_msgs/html/index-msg.html)/Object` type.

I found the `object_sensor` is publishing objects like following behaviors:
1. if the object is a vehicle, then the `Object.pose.position` will be the position on the ground(x-y plane), but it will be adjust to pivot point when publishing `Marker`.
2. if the object is a walker, then the `Object.pose.position` will be the pivot point of bounding box, and there is no adjustment before publishing `Marker`.

the reason,  that I consider these behaviors are problematic, is the behaviors are not uniform, so I made this patch.
the reason, that I choose to modify the `walker.py`, is that the position is intentionally adjusted when publishing `Marker` in `vehicle.py`, so I think maintainers are proposing to publish `objects` topic with position on the ground, but not the pivot point.

please help me to confirm this MR, thanks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/648)
<!-- Reviewable:end -->
