### PR TITLE
MarkerSensor: disable Vegetation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Latest
 
+## CARLA-ROS-Bridge 0.9.13
+
+* Disable vegetation on MarkerSensor to prevent from millions of boxes in maps with larger vegetation
+
 ## CARLA-ROS-Bridge 0.9.12
 
 *   Fixed scenario runner node shutdown for foxy

--- a/carla_ros_bridge/src/carla_ros_bridge/marker_sensor.py
+++ b/carla_ros_bridge/src/carla_ros_bridge/marker_sensor.py
@@ -34,7 +34,7 @@ OBJECT_LABELS = {
     carla.CityObjectLabel.RoadLines: ColorRGBA(r=157.0/255.0, g=234.0/255.0, b=50.0/255.0, a=0.8),
     carla.CityObjectLabel.Roads: ColorRGBA(r=128.0/255.0, g=64.0/255.0, b=128.0/255.0, a=0.8),
     carla.CityObjectLabel.Sidewalks: ColorRGBA(r=244.0/255.0, g=35.0/255.0, b=232.0/255.0, a=0.8),
-    carla.CityObjectLabel.Vegetation: ColorRGBA(r=107.0/255.0, g=142.0/255.0, b=35.0/255.0, a=0.8),
+    #carla.CityObjectLabel.Vegetation: ColorRGBA(r=107.0/255.0, g=142.0/255.0, b=35.0/255.0, a=0.8),
     #carla.CityObjectLabel.Vehicles: ColorRGBA(r=0.0/255.0, g=0.0/255.0, b=142.0/255.0, a=0.8),
     carla.CityObjectLabel.Walls: ColorRGBA(r=102.0/255.0, g=102.0/255.0, b=156.0/255.0, a=0.8),
     carla.CityObjectLabel.TrafficSigns: ColorRGBA(r=220.0/255.0, g=220.0/255.0, b=0.0/255.0, a=0.8),


### PR DESCRIPTION
The number of vegetation bouunding boxes can explode due to the duplication of small vegetation pieces. Millions of bounding boxes are not useful, taking minutes to load and consuming gigabytes of memory.

Background: The number of bounding boxes on a custom map with large vegetation areas increased from 10k in carla0.9.11 to 2.7M in carla0.9.13. The extreme number makes the MarkerSensor unusable, at 8 minute load time and 20GB of required memory for the static markers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/655)
<!-- Reviewable:end -->
