### PR TITLE
install .yaml .json .py files for the test to work

### DIFF
--- a/carla_ros_bridge/CMakeLists.txt
+++ b/carla_ros_bridge/CMakeLists.txt
@@ -28,6 +28,15 @@ if(${ROS_VERSION} EQUAL 1)
 
   install(FILES test/ros_bridge_client.test
           DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
+          
+  install(FILES test/settings.yaml
+          DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/test)
+
+  install(FILES test/test_objects.json
+          DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/test)
+
+  install(PROGRAMS test/ros_bridge_client.py
+          DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})
 
   install(DIRECTORY launch/
           DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch)


### PR DESCRIPTION
This fixes the issue of rostest not finding the settings files in the shared directory of the catkin workspace

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/672)
<!-- Reviewable:end -->
