### PR TITLE
Fix tf2_eigen compilation issues

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -23,6 +23,10 @@ fi
 
 echo ADDITIONAL PACKAGES $ADDITIONAL_PACKAGES
 
+# Apply fix for GPG key expired error
+# Link: https://github.com/osrf/docker_images/issues/697#issuecomment-1819626877
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 4B63CF8FDE49746E98FA01DDAD19BAB3CBF125EA
+
 sudo apt update
 sudo apt-get install --no-install-recommends -y \
     python$PYTHON_SUFFIX-pip \

--- a/pcl_recorder/CMakeLists.txt
+++ b/pcl_recorder/CMakeLists.txt
@@ -66,7 +66,7 @@ elseif(${ROS_VERSION} EQUAL 2)
   add_executable(${PROJECT_NAME}_node src/PclRecorderROS2.cpp src/mainROS2.cpp)
 
   ament_target_dependencies(${PROJECT_NAME}_node rclcpp sensor_msgs
-                            pcl_conversions tf2 tf2_ros)
+                            pcl_conversions tf2 tf2_ros tf2_eigen)
 
   target_link_libraries(${PROJECT_NAME}_node ${Boost_SYSTEM_LIBRARY}
                         ${PCL_LIBRARIES})

--- a/pcl_recorder/CMakeLists.txt
+++ b/pcl_recorder/CMakeLists.txt
@@ -65,8 +65,14 @@ elseif(${ROS_VERSION} EQUAL 2)
 
   add_executable(${PROJECT_NAME}_node src/PclRecorderROS2.cpp src/mainROS2.cpp)
 
-  ament_target_dependencies(${PROJECT_NAME}_node rclcpp sensor_msgs
-                            pcl_conversions tf2 tf2_ros tf2_eigen)
+  ament_target_dependencies(
+    ${PROJECT_NAME}_node
+    rclcpp
+    sensor_msgs
+    pcl_conversions
+    tf2
+    tf2_ros
+    tf2_eigen)
 
   target_link_libraries(${PROJECT_NAME}_node ${Boost_SYSTEM_LIBRARY}
                         ${PCL_LIBRARIES})


### PR DESCRIPTION
When trying to compile the master branch, the following error is raised

```
--- stderr: pcl_recorder                                
In file included from /home/felipe/Documents/Github/carla_ws/src/ros-bridge/pcl_recorder/src/mainROS2.cpp:7:
/home/felipe/Documents/Github/carla_ws/src/ros-bridge/pcl_recorder/include/PclRecorderROS2.h:13:10: fatal error: tf2_eigen/tf2_eigen.h: No such file or directory
   13 | #include <tf2_eigen/tf2_eigen.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
gmake[2]: *** [CMakeFiles/pcl_recorder_node.dir/build.make:90: CMakeFiles/pcl_recorder_node.dir/src/mainROS2.cpp.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
In file included from /home/felipe/Documents/Github/carla_ws/src/ros-bridge/pcl_recorder/src/PclRecorderROS2.cpp:13:
/home/felipe/Documents/Github/carla_ws/src/ros-bridge/pcl_recorder/include/PclRecorderROS2.h:13:10: fatal error: tf2_eigen/tf2_eigen.h: No such file or directory
   13 | #include <tf2_eigen/tf2_eigen.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

This can be fixed by adding tf2_eigen as dependency in CMakeLists.txt

This error is likely caused by a change in dependencies relationship whitin pcl_recorder target dependecies. For example, pcl_recorder depends in A and A depends on tf2_eigen, so tf2_eigen is imported as a dependency to pcl_recorder as well. For some unknown reason, A doesn't import tf2_eigen as dependency anymore, so pcl_recorder has a missing depency, as it uses tf2_eigen directly but doesn't lists as a dependency.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/709)
<!-- Reviewable:end -->
