### PR TITLE
Fix fromMsg missing symbol rviz plugin error

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -23,6 +23,10 @@ fi
 
 echo ADDITIONAL PACKAGES $ADDITIONAL_PACKAGES
 
+# Apply fix for GPG key expired error
+# Link: https://github.com/osrf/docker_images/issues/697#issuecomment-1819626877
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 4B63CF8FDE49746E98FA01DDAD19BAB3CBF125EA
+
 sudo apt update
 sudo apt-get install --no-install-recommends -y \
     python$PYTHON_SUFFIX-pip \

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -46,6 +46,7 @@ sudo apt-get install --no-install-recommends -y \
     wget \
     qt5-default \
     ros-$ROS_DISTRO-pcl-conversions \
+    ros-$ROS_DISTRO-tf2-geometry-msgs \
     $ADDITIONAL_PACKAGES
 
 pip$PYTHON_SUFFIX install --upgrade pip$PYTHON_SUFFIX

--- a/rviz_carla_plugin/CMakeLists.txt
+++ b/rviz_carla_plugin/CMakeLists.txt
@@ -52,6 +52,7 @@ elseif(${ROS_VERSION} EQUAL 2)
   find_package(carla_ros_scenario_runner_types COMPONENTS)
   find_package(pluginlib REQUIRED)
   find_package(rviz_ogre_vendor REQUIRED)
+  find_package(tf2_geometry_msgs REQUIRED)
 
   set(CMAKE_AUTOMOC ON)
 
@@ -74,7 +75,8 @@ elseif(${ROS_VERSION} EQUAL 2)
                                            plugin_description_ros2.xml)
 
   ament_target_dependencies(rviz_carla_plugin rclcpp carla_msgs nav_msgs
-                            carla_ros_scenario_runner_types rviz_common)
+                            carla_ros_scenario_runner_types rviz_common
+                            tf2_geometry_msgs)
 
   ament_export_libraries(${PROJECT_NAME})
 

--- a/rviz_carla_plugin/CMakeLists.txt
+++ b/rviz_carla_plugin/CMakeLists.txt
@@ -74,9 +74,14 @@ elseif(${ROS_VERSION} EQUAL 2)
   pluginlib_export_plugin_description_file(rviz_common
                                            plugin_description_ros2.xml)
 
-  ament_target_dependencies(rviz_carla_plugin rclcpp carla_msgs nav_msgs
-                            carla_ros_scenario_runner_types rviz_common
-                            tf2_geometry_msgs)
+  ament_target_dependencies(
+    rviz_carla_plugin
+    rclcpp
+    carla_msgs
+    nav_msgs
+    carla_ros_scenario_runner_types
+    rviz_common
+    tf2_geometry_msgs)
 
   ament_export_libraries(${PROJECT_NAME})
 

--- a/rviz_carla_plugin/package.xml
+++ b/rviz_carla_plugin/package.xml
@@ -18,6 +18,7 @@
 
   <build_depend>qtbase5-dev</build_depend>
   <depend>carla_msgs</depend>
+  <build_depend>tf2_geometry_msgs</build_depend>
   <build_depend>nav_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>carla_ros_scenario_runner_types</build_depend>
@@ -27,7 +28,7 @@
   <exec_depend>libqt5-core</exec_depend>
   <exec_depend>libqt5-gui</exec_depend>
   <exec_depend>libqt5-widgets</exec_depend>
-  
+
   <export>
       <rviz condition="$ROS_VERSION == 1" plugin="${prefix}/plugin_description.xml"/> -->
       <build_type condition="$ROS_VERSION == 1">catkin</build_type>

--- a/rviz_carla_plugin/src/carla_control_panel_ROS2.cpp
+++ b/rviz_carla_plugin/src/carla_control_panel_ROS2.cpp
@@ -22,7 +22,7 @@
 #include <chrono>
 #include <iomanip>
 
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include <tf2/utils.h>
 
 #include <OgreCamera.h>

--- a/rviz_carla_plugin/src/carla_control_panel_ROS2.cpp
+++ b/rviz_carla_plugin/src/carla_control_panel_ROS2.cpp
@@ -22,6 +22,7 @@
 #include <chrono>
 #include <iomanip>
 
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2/utils.h>
 
 #include <OgreCamera.h>


### PR DESCRIPTION
This PR fixes the problem described here https://github.com/carla-simulator/ros-bridge/issues/711

The solution was found after some discussion at https://github.com/ros2/geometry2/issues/639

When loading the rviz plugin, the system crashes with a error [translated to](http://demangler.com/)

```
undefined symbol: tf2::fromMsg(geometry_msgs::msg::Quaternion_<std::allocator<void> > const&, tf2::Quaternion&)
```

It was due to the definition of `fromMsg` being missing. This function is declared at `tf2_geometry_msgs/tf2_geometry_msgs.hpp`, so this file is included and tf2_geometry_msgs is linked to our plugin

Closes #711

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/713)
<!-- Reviewable:end -->
