### PR TITLE
changed ipc mode for ros2 support

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -35,4 +35,5 @@ echo "Using $DOCKER_IMAGE_NAME:$TAG"
 docker run \
     -it --rm \
     --net=host \
+    --ipc=host \
     "$DOCKER_IMAGE_NAME:$TAG" "$@"


### PR DESCRIPTION
Hi, I am using the bridge with docker. While it is working nicely with ros1 it does not work with ros2 because of [how it uses shared memory](https://github.com/eProsima/Fast-DDS/issues/5396). This results in ros2 nodes not being able to communicate between different docker containers. By changing the ipc mode this is solved.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/carla-simulator/ros-bridge/757)
<!-- Reviewable:end -->
